### PR TITLE
fix(cookie-block): 修正正式環境無法使用 cookie 問題

### DIFF
--- a/components/Header/OtherHeader.vue
+++ b/components/Header/OtherHeader.vue
@@ -12,7 +12,7 @@
       </nuxt-link>
     </nav>
     <button
-      v-if="isLogin"
+      v-if="token"
       @click="logout"
     >
       登出
@@ -20,7 +20,7 @@
   </header>
 </template>
 <script lang="ts" setup>
-const isLogin: any = useCookie('isLogin');
+const token: any = useCookie('token');
 
 const userStore = useUserStore();
 
@@ -31,7 +31,7 @@ const navList = computed<any>(() => {
     { name: '訂閱', path: '/subscription-plan' },
     { name: '搜尋', path: '/search' }
   ];
-  const list = isLogin.value ? authPath : notAuthPath;
+  const list = token.value ? authPath : notAuthPath;
   return [...list, ...commonPath];
 });
 
@@ -40,7 +40,7 @@ const logout = async () => {
     method: 'post',
     credentials: 'include'
   });
-  isLogin.value = undefined;
+  token.value = undefined;
   userStore.$reset();
 };
 </script>

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -5,8 +5,8 @@ export default defineNuxtRouteMiddleware(() => {
     return;
   }
 
-  const isLogin = useCookie('isLogin');
-  if (isLogin.value) {
+  const token = useCookie('token');
+  if (token.value) {
     return;
   }
   // eslint-disable-next-line consistent-return

--- a/pages/article/[articleId].vue
+++ b/pages/article/[articleId].vue
@@ -7,13 +7,13 @@
 </template>
 <script setup lang="ts">
 const route = useRoute();
-const isLogin: any = useCookie('isLogin');
+const token: any = useCookie('token');
 
 const articleType = computed(() =>
   route.params.articleId[0] === 'M' ? '雜誌' : '新聞'
 );
 
 const hiddenArticle = computed(
-  () => !isLogin.value && articleType.value === '雜誌'
+  () => !token.value && articleType.value === '雜誌'
 );
 </script>

--- a/pages/login-register/index.vue
+++ b/pages/login-register/index.vue
@@ -59,7 +59,7 @@
     >
       Submit
     </button>
-    <template v-if="isLogin">
+    <template v-if="token">
       <div>3秒後跳轉至新聞....</div>
     </template>
     <p
@@ -74,7 +74,12 @@
 const router = useRouter();
 
 const userStore = useUserStore();
-const isLogin: any = useCookie('isLogin');
+
+const cookieOption = {
+  maxAge: 60 * 60
+};
+
+const token: any = useCookie('token', cookieOption);
 
 const mode = ref('login');
 
@@ -138,7 +143,7 @@ const submit = async () => {
 
   if (res?.data?.value?.status && res?.data?.value?.data?.id) {
     userStore.SET_USER_INFO(res?.data?.value?.data);
-    isLogin.value = 'true';
+    token.value = res?.data?.value?.data?.token;
     setTimeout(() => {
       router.replace('/news');
     }, 3000);

--- a/pages/subscription-plan/index.vue
+++ b/pages/subscription-plan/index.vue
@@ -4,12 +4,12 @@
   <div>{{ text }}</div>
 </template>
 <script lang="ts" setup>
-const isLogin = useCookie('isLogin');
+const token: any = useCookie('token');
 
 const text = ref<string>('');
 
 const subscribe = () => {
-  if (isLogin.value) {
+  if (token.value) {
     text.value = '確認為登入狀態可以訂閱';
   } else {
     text.value = '請先登入！';

--- a/plugins/api.ts
+++ b/plugins/api.ts
@@ -1,14 +1,19 @@
 export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig();
   const userStore = useUserStore();
-  const isLogin = useCookie('isLogin');
   const $api = $fetch.create({
     baseURL: `${config.public.apiBase}/api/v1`,
-    onRequest({ request, options, error }) {},
+    onRequest({ request, options, error }) {
+      const token = useCookie('token');
+      if (token.value) {
+        options.headers = { authorization: `Bearer ${token.value}` };
+      }
+    },
     onResponseError({ request, response, options }): any {
       // 身份未授權
       if (response.status === 401) {
-        isLogin.value = undefined;
+        const token = useCookie('token');
+        token.value = undefined;
         userStore.$reset();
         return navigateTo('/login-register');
       }


### PR DESCRIPTION
問題:

1. render 正式環境無法使用後端給的 cookie

原因:

1. 跨域問題，且 render 的預設域名 onrender.com 無法透過設定 cookie domain 讓前端可以存取

調整:

1. 改成從 res body 接入 token，前端再設定到 cookie 上

2. 發送請求時將 token 改帶在 request header 的 authorization