### PR TITLE
chore(api): 建立 api 流程

### DIFF
--- a/components/Header/OtherHeader.vue
+++ b/components/Header/OtherHeader.vue
@@ -13,7 +13,7 @@
     </nav>
     <button
       v-if="token"
-      @click="logout"
+      @click="logoutHandler"
     >
       登出
     </button>
@@ -23,6 +23,7 @@
 const token: any = useCookie('token');
 
 const userStore = useUserStore();
+const { logout } = useMemberApi();
 
 const navList = computed<any>(() => {
   const authPath = [{ name: '會員中心', path: '/member' }];
@@ -35,12 +36,11 @@ const navList = computed<any>(() => {
   return [...list, ...commonPath];
 });
 
-const logout = async () => {
-  await useApi('/member/logout', {
-    method: 'post',
-    credentials: 'include'
-  });
-  token.value = undefined;
-  userStore.$reset();
+const logoutHandler = async () => {
+  const { status } = await logout();
+  if (status) {
+    token.value = undefined;
+    userStore.$reset();
+  }
 };
 </script>

--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -1,11 +1,21 @@
 import type { UseFetchOptions } from 'nuxt/app';
 
-export default function useApi<T>(
+export default async function useApi<T>(
   url: string | (() => string),
   options: UseFetchOptions<T> = {}
 ) {
-  return useFetch(url, {
+  const { data, error }: any = await useFetch(url, {
     ...options,
+    credentials: 'include',
     $fetch: useNuxtApp().$api
   });
+
+  const res = data?.value?.status
+    ? data.value
+    : {
+        ...error.value?.data,
+        status: false
+      };
+
+  return res;
 }

--- a/composables/useMemberApi.ts
+++ b/composables/useMemberApi.ts
@@ -1,0 +1,57 @@
+class memberApi {
+  static async register(
+    params: RegisterRequestType
+  ): Promise<ApiResponseType<LoginRegisterResponseType>> {
+    const body = {
+      name: params.name,
+      email: params.email,
+      password: params.password
+    };
+    const res = await useApi('/member/register', {
+      method: 'post',
+      body
+    });
+
+    return res;
+  }
+
+  static async login(
+    params: LoginRequestType
+  ): Promise<ApiResponseType<LoginRegisterResponseType>> {
+    const body = {
+      email: params.email,
+      password: params.password
+    };
+    const res = await useApi('/member/login', {
+      method: 'post',
+      body
+    });
+
+    return res;
+  }
+
+  static async logout(): Promise<ApiResponseType<undefined>> {
+    const res = await useApi('/member/logout', {
+      method: 'post'
+    });
+
+    return res;
+  }
+
+  static async updatePassword(params: {
+    [key: string]: PasswordType;
+  }): Promise<ApiResponseType<undefined>> {
+    const body = {
+      oldPassword: params.oldPassword,
+      newPassword: params.newPassword
+    };
+    const res = await useApi('/member/password', {
+      method: 'patch',
+      body
+    });
+
+    return res;
+  }
+}
+
+export default () => memberApi;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -70,7 +70,9 @@ export default defineNuxtConfig({
       // ... or scan modules nested one level deep with a specific name and file extension
       'composables/*/index.{ts,js,mjs,mts}',
       // ... or scan all modules within given directory
-      'composables/**'
+      'composables/**',
+      'types/*.ts',
+      'types/**/*.ts'
     ]
   },
   runtimeConfig: {

--- a/pages/login-register/index.vue
+++ b/pages/login-register/index.vue
@@ -72,8 +72,8 @@
 </template>
 <script setup lang="ts">
 const router = useRouter();
-
 const userStore = useUserStore();
+const { login, register } = useMemberApi();
 
 const cookieOption = {
   maxAge: 60 * 60
@@ -81,7 +81,7 @@ const cookieOption = {
 
 const token: any = useCookie('token', cookieOption);
 
-const mode = ref('login');
+const mode = ref<'login' | 'register'>('login');
 
 const initialState = {
   name: '',
@@ -89,7 +89,7 @@ const initialState = {
   password: ''
 };
 
-const formState = reactive({ ...initialState });
+const formState = reactive<RegisterRequestType>({ ...initialState });
 
 const btnDisabled = computed(
   () =>
@@ -105,50 +105,19 @@ const switchMode = () => {
   Object.assign(formState, initialState);
 };
 
-const login = async () => {
-  try {
-    const res = await useApi('/member/login', {
-      method: 'post',
-      body: {
-        email: formState.email,
-        password: formState.password
-      },
-      credentials: 'include'
-    });
-    return res;
-  } catch (error) {
-    return error;
-  }
-};
-
-const register = async () => {
-  try {
-    const res = await useApi('/member/register', {
-      method: 'post',
-      body: {
-        name: formState.name,
-        email: formState.email,
-        password: formState.password
-      },
-      credentials: 'include'
-    });
-    return res;
-  } catch (error) {
-    return error;
-  }
-};
-
 const submit = async () => {
-  const res: any = mode.value === 'login' ? await login() : await register();
+  const { status, data, message } =
+    mode.value === 'login' ? await login(formState) : await register(formState);
 
-  if (res?.data?.value?.status && res?.data?.value?.data?.id) {
-    userStore.SET_USER_INFO(res?.data?.value?.data);
-    token.value = res?.data?.value?.data?.token;
+  if (status) {
+    userStore.SET_USER_INFO(data);
+    token.value = data?.token;
+
     setTimeout(() => {
       router.replace('/news');
     }, 3000);
   } else {
-    warnMessage.value = res?.error?.value?.data?.message;
+    warnMessage.value = message;
   }
 };
 </script>

--- a/pages/member/account/password.vue
+++ b/pages/member/account/password.vue
@@ -50,13 +50,15 @@
   </form>
 </template>
 <script lang="ts" setup>
+const { updatePassword } = useMemberApi();
+
 const initState = {
   oldPassword: '',
   newPassword: '',
   confirmPassword: ''
 };
 
-const formState = reactive({ ...initState });
+const formState = reactive<{ [key: string]: PasswordType }>({ ...initState });
 
 const hintMessage = ref<string>('');
 
@@ -67,32 +69,14 @@ const btnDisabled = computed(
     !formState.confirmPassword?.trim()
 );
 
-const updatePassword = async () => {
-  try {
-    const res = await useApi('/member/password', {
-      method: 'patch',
-      body: {
-        oldPassword: formState.oldPassword,
-        newPassword: formState.newPassword
-      },
-      credentials: 'include'
-    });
-    return res;
-  } catch (error) {
-    return error;
-  }
-};
-
 const submit = async () => {
-  const res: any = await updatePassword();
+  const { status, message } = await updatePassword(formState);
 
-  if (res?.data?.value?.status) {
+  if (status) {
     Object.assign(formState, initState);
-    hintMessage.value = res?.data?.value?.message;
+    hintMessage.value = message;
   } else {
-    hintMessage.value = res?.error?.value?.data?.message;
+    hintMessage.value = message;
   }
-
-  console.log('password :>> ', res);
 };
 </script>

--- a/plugins/api.ts
+++ b/plugins/api.ts
@@ -3,7 +3,7 @@ export default defineNuxtPlugin(() => {
   const userStore = useUserStore();
   const $api = $fetch.create({
     baseURL: `${config.public.apiBase}/api/v1`,
-    onRequest({ request, options, error }) {
+    onRequest({ request, options }) {
       const token = useCookie('token');
       if (token.value) {
         options.headers = { authorization: `Bearer ${token.value}` };

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -1,11 +1,5 @@
 import { defineStore } from 'pinia';
 
-interface UserInfo {
-  id: string;
-  name: string;
-  email: string;
-}
-
 export const useUserStore = defineStore('user', {
   state: () => ({
     id: '',

--- a/types/apiType.ts
+++ b/types/apiType.ts
@@ -1,0 +1,22 @@
+declare global {
+  interface ApiResponseType<T> {
+    status?: boolean;
+    message: string;
+    data: T;
+  }
+
+  interface LoginRequestType {
+    email: UserInfo['email'];
+    password: PasswordType;
+  }
+
+  interface RegisterRequestType extends LoginRequestType {
+    name: UserInfo['name'];
+  }
+
+  interface LoginRegisterResponseType extends UserInfo {
+    token: TokenType;
+  }
+}
+
+export {};

--- a/types/userType.ts
+++ b/types/userType.ts
@@ -1,0 +1,13 @@
+declare global {
+  type PasswordType = string;
+
+  type TokenType = string;
+
+  interface UserInfo {
+    id: string;
+    name: string;
+    email: string;
+  }
+}
+
+export {};


### PR DESCRIPTION
1. 依據 api 種類細分，目前新增 useMemberApi 管理會員相關 api，並加上型別判斷

2. 統一 api 回傳格式，useFetch 會回傳一個物件，取其中的 data、error 包裝統一格式 { status, data, message }

3. 加上 types 檔案