### PR TITLE
fix(requireImage): 修正 requireImage 無法載入圖片問題

### DIFF
--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <p>新聞首頁 3-1</p>
-
     <nuxt-link :to="`/article/${articleId}`"><div>新聞文章1</div></nuxt-link>
   </div>
 </template>

--- a/utils/requireImage.ts
+++ b/utils/requireImage.ts
@@ -1,2 +1,8 @@
-export default (path: string) =>
-  new URL(`../assets/image/${path}`, import.meta.url).href;
+const glob = import.meta.glob('~/assets/image/**', {
+  eager: true
+});
+const images = Object.fromEntries(
+  Object.entries(glob).map(([key, value]: any) => [key, value.default])
+);
+
+export default (path: string) => images[`/assets/image/${path}`];


### PR DESCRIPTION
問題:

1. requireImage 有時候無法正確載入圖片，會報警告: Hydration style mismatch

原因:

1. vite 文件提到 SSR 使用 import.meta.url 會有問題，因為 server 端無法知道用戶端的 host

調整:

1. 使用 import.meta.glob 作為動態載入方法