### PR TITLE
fix(base64): 修正 base64 背景圖無法正確顯示

### DIFF
--- a/components/NFooter.vue
+++ b/components/NFooter.vue
@@ -14,6 +14,7 @@
         <cite class="fst-normal">
           Illustration by
           <a
+            target="_blank"
             class="footer-link"
             href="https://www.behance.net/STRELKAX"
           >
@@ -21,6 +22,7 @@
           </a>
           from
           <a
+            target="_blank"
             class="footer-link"
             href="https://icons8.com/illustrations"
           >

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,6 +47,7 @@ export default defineNuxtConfig({
     }
   },
   vite: {
+    build: { assetsInlineLimit: 0 },
     css: {
       preprocessorOptions: {
         scss: {


### PR DESCRIPTION
問題:

1. footer 追蹤我們的社群 icon 背景圖編譯呈 base64 後無法正確讀取

調整:

1. 設定 vite config assetsInlineLimit 為 0，禁止轉變圖片為 base64