### PR TITLE
style(layout): 調整 layout

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -31,7 +31,9 @@ provide('isPc', isPc);
 @include media-breakpoint-down(md) {
   .layouts,
   ::v-deep(.layouts) {
-    padding-top: $mobile-header-height;
+    &:not(.login-layout) {
+      padding-top: $mobile-header-height;
+    }
   }
 }
 </style>

--- a/layouts/member.vue
+++ b/layouts/member.vue
@@ -48,7 +48,7 @@ const changeTab = (tabItem: any) => {
   }
 };
 
-onMounted(() => {
+watchEffect(() => {
   currentTab.value = memberSubNav.find((e) => String(route.name).includes(e.value))?.label || '會員中心';
 });
 </script>


### PR DESCRIPTION
1. 調整 login layout 手機板不需要 padding-top，因為沒有 fixed 的  header

2. 調整 member layout 用 watchEffect 偵測 currentTab（同 default layout）