### PR TITLE
feat(slideRoute): 加上 transition slide route

### DIFF
--- a/components/NTabs.vue
+++ b/components/NTabs.vue
@@ -57,6 +57,8 @@ const slideTabHandler = (index: number) => {
 };
 
 const clickTab: any = (item: TabItemType, index: number): void => {
+  if (currentTab.value === item?.label) return;
+
   slideTabHandler(index);
 
   currentTab.value = item.label;
@@ -69,13 +71,23 @@ onMounted(() => {
   nTabs.on(clickTab);
 });
 
-watchImmediate(
+const initTabHandler = () => {
+  const index = props.tabList.findIndex((e) => e.label === currentTab.value);
+  slideTabHandler(index === -1 ? 0 : index);
+};
+
+onMounted(async () => {
+  await nextTick(() => {
+    initTabHandler();
+  });
+});
+
+watch(
   () => currentTab.value,
-  (newVal, oldVal) => {
-    if (!oldVal && newVal) {
-      const index = props.tabList.findIndex((e) => e.label === newVal);
-      slideTabHandler(index === -1 ? 0 : index);
-    }
+  async () => {
+    await nextTick(() => {
+      initTabHandler();
+    });
   }
 );
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,7 +7,19 @@
         @change-tab="changeTab"
       />
     </nav>
-    <slot />
+    <div
+      v-if="$route.path.startsWith('/news') || ($route.name === 'magazine' && !$route.params.category)"
+      ref="pageRef"
+      v-touch:swipe.left="swiperHeader"
+      v-touch:swipe.right="swiperHeader"
+      v-touch:press="pressHandler"
+      v-touch:release="releaseHandler"
+      class="page-container"
+      :style="transformStyle"
+    >
+      <slot />
+    </div>
+    <slot v-else />
     <button
       v-if="token"
       @click="logoutHandler"
@@ -21,6 +33,10 @@
 import type { TabItemType } from '@/components/NTabs.vue';
 
 const token: any = useCookie('token');
+const pageRef = ref<HTMLElement | null>(null);
+const swiperRef = useSwipe(pageRef);
+
+const isMobile = inject<any>('isMobile');
 
 const userStore = useUserStore();
 const { logout } = useUserApi();
@@ -48,6 +64,49 @@ const changeTab = (tabItem: TabItemType) => {
 
 watchEffect(() => {
   currentTab.value =
-    (route.query.category as string) || newsNav.find((e) => String(route.path).includes(e.value))?.label || '';
+    (route.query.category as string) ||
+    newsNav.find((e) => String(route.path).includes(e.value))?.label ||
+    ((route.params.articleId as string).startsWith('M-') && newsNav.find((e) => e.value === '/magazine')?.label) ||
+    (route.params.category as string) ||
+    '';
 });
+
+const swiperRoute = computed(() => {
+  const index = newsNav.findIndex((e) => e.label === currentTab.value);
+  const prev = newsNav[index - 1]?.value || newsNav[0]?.value;
+  const next = newsNav[index + 1]?.value || newsNav[newsNav.length - 1]?.value;
+
+  return { prev, next };
+});
+
+const isPress = ref<boolean>(false);
+const transformStyle = computed(() => ({
+  transform: isPress.value ? `translateX(${swiperRef.coordsEnd.x - swiperRef.coordsStart.x}px)` : ''
+}));
+
+const pressHandler = () => {
+  if (!isMobile.value) return;
+  isPress.value = true;
+};
+
+const releaseHandler = () => {
+  if (!isMobile.value) return;
+  setTimeout(() => {
+    isPress.value = false;
+  }, 100);
+};
+
+const swiperHeader = (direction: string) => {
+  if (!isMobile.value) return;
+  if (direction === 'left') {
+    navigateTo(swiperRoute.value.next);
+  } else {
+    navigateTo(swiperRoute.value.prev);
+  }
+};
 </script>
+<style lang="scss" scoped>
+.page-container {
+  transition: transform 0.1s ease-out;
+}
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "nuxt-swiper": "^1.2.2",
         "pinia": "^2.1.7",
         "vue": "^3.4.21",
-        "vue-router": "^4.3.0"
+        "vue-router": "^4.3.0",
+        "vue3-touch-events": "^4.1.8"
       },
       "devDependencies": {
         "@nuxtjs/eslint-config-typescript": "^12.1.0",
@@ -16461,6 +16462,11 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
       "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
     },
+    "node_modules/vue3-touch-events": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vue3-touch-events/-/vue3-touch-events-4.1.8.tgz",
+      "integrity": "sha512-8Zs0mj5k/7R579JHsc5w1V2IqAkNlz2gJs18bRV4T5WyCMfd5sBf2ESJ2xR8z+n7ypgK8fQO5MmDOPal0Evf3Q=="
+    },
     "node_modules/watchpack": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
@@ -28154,6 +28160,11 @@
           "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
         }
       }
+    },
+    "vue3-touch-events": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vue3-touch-events/-/vue3-touch-events-4.1.8.tgz",
+      "integrity": "sha512-8Zs0mj5k/7R579JHsc5w1V2IqAkNlz2gJs18bRV4T5WyCMfd5sBf2ESJ2xR8z+n7ypgK8fQO5MmDOPal0Evf3Q=="
     },
     "watchpack": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "nuxt-swiper": "^1.2.2",
     "pinia": "^2.1.7",
     "vue": "^3.4.21",
-    "vue-router": "^4.3.0"
+    "vue-router": "^4.3.0",
+    "vue3-touch-events": "^4.1.8"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.1.0",

--- a/pages/article/[category]/[articleId].vue
+++ b/pages/article/[category]/[articleId].vue
@@ -1,5 +1,6 @@
 <template>
   <div>文章內頁 3-2、5-3</div>
+  <div>{{ `種類：${$route.params.category}` }}</div>
   <div>{{ `文章 ID:${$route.params.articleId}` }}</div>
   <div>{{ `${articleType}文章` }}</div>
 
@@ -9,11 +10,7 @@
 const route = useRoute();
 const token: any = useCookie('token');
 
-const articleType = computed(() =>
-  route.params.articleId[0] === 'M' ? '雜誌' : '新聞'
-);
+const articleType = computed(() => (route.params.articleId[0] === 'M' ? '雜誌' : '新聞'));
 
-const hiddenArticle = computed(
-  () => !token.value && articleType.value === '雜誌'
-);
+const hiddenArticle = computed(() => !token.value && articleType.value === '雜誌');
 </script>

--- a/pages/magazine/[category].vue
+++ b/pages/magazine/[category].vue
@@ -2,7 +2,9 @@
   <div>{{ $route.params.category }}</div>
   <h1>雜誌文章列表 5-2</h1>
 
-  <nuxt-link :to="`/article/${articleId}`"><div>雜誌文章1</div></nuxt-link>
+  <nuxt-link :to="`/article/${$route.params.category}/${articleId}`"
+    ><div>{{ `${$route.params.category}文章` }}</div></nuxt-link
+  >
   <NPagination
     :total-pages="20"
     :current-page="currentPage"

--- a/pages/magazine/index.vue
+++ b/pages/magazine/index.vue
@@ -1,10 +1,38 @@
 <template>
-  <div>雜誌種類列表頁 5-1</div>
-  <h1>精選雜誌</h1>
-  <p>
-    <nuxt-link :to="`/magazine/${category}`">{{ category }}</nuxt-link>
-  </p>
+  <div>
+    <div>雜誌種類列表頁 5-1</div>
+    <h1>精選雜誌</h1>
+    <p>
+      <nuxt-link :to="`/magazine/${category}`">{{ category }}</nuxt-link>
+    </p>
+  </div>
 </template>
 <script setup lang="ts">
+definePageMeta({
+  pageTransition: {
+    name: 'slide-left',
+    mode: 'out-in'
+  },
+  keepalive: true
+});
+
 const category = ref('科技前沿周刊');
 </script>
+<style lang="scss" scoped>
+@include media-breakpoint-down(md) {
+  .slide-left-enter-active,
+  .slide-left-leave-active {
+    transition: all 0.2s;
+  }
+
+  .slide-left-enter-from {
+    opacity: 0;
+    transform: translate(50px, 0);
+  }
+
+  .slide-left-leave-to {
+    opacity: 0;
+    transform: translate(-50px, 0);
+  }
+}
+</style>

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -1,9 +1,86 @@
 <template>
   <div>
+    <p>
+      {{ $route.query.category }}
+    </p>
     <p>新聞首頁 3-1</p>
-    <nuxt-link :to="`/article/${articleId}`"><div>新聞文章1</div></nuxt-link>
+    <nuxt-link
+      v-for="item in newsArticleList"
+      :key="item.label"
+      :to="`/article/${item.label}/${articleId}`"
+      ><div>{{ `${item.label}新聞文章` }}</div></nuxt-link
+    >
   </div>
 </template>
 <script setup lang="ts">
+definePageMeta({
+  pageTransition: {
+    name: 'slide-right',
+    mode: 'out-in'
+  },
+  keepalive: true,
+  middleware(to, from) {
+    if (to.meta.pageTransition && typeof to.meta.pageTransition !== 'boolean') {
+      const { newsNav } = useNav();
+      const fromIndex = newsNav.findIndex(
+        (e) =>
+          e.label === from.query.category ||
+          (from.name === 'news' && !from.query.category) ||
+          (e.value === '/magazine' && String(from.name).includes('magazine'))
+      );
+      const toIndex = newsNav.findIndex(
+        (e) =>
+          e.label === to.query.category ||
+          (to.name === 'news' && !to.query.category) ||
+          (e.value === '/magazine' && String(to.name).includes('magazine'))
+      );
+      // eslint-disable-next-line no-param-reassign
+      to.meta.pageTransition.name = +toIndex > +fromIndex ? 'slide-left' : 'slide-right';
+    }
+  }
+});
+
 const articleId = ref<string>('N-87');
+
+const route = useRoute();
+
+const { newsNav } = useNav();
+
+const newsArticleList = computed(() => {
+  const list = newsNav.filter((e) => e.value !== '/magazine');
+  if (route.query.category) {
+    return list.filter((e) => e.label === route.query.category);
+  }
+  return list;
+});
 </script>
+<style lang="scss" scoped>
+@include media-breakpoint-down(md) {
+  .slide-left-enter-active,
+  .slide-left-leave-active,
+  .slide-right-enter-active,
+  .slide-right-leave-active {
+    transition: all 0.2s;
+  }
+
+  .slide-left-enter-from {
+    opacity: 0;
+    transform: translate(50px, 0);
+  }
+
+  .slide-left-leave-to {
+    opacity: 0;
+    transform: translate(-50px, 0);
+  }
+
+  .slide-right-enter-from {
+    opacity: 0;
+    transform: translate(-50px, 0);
+  }
+
+  .slide-right-leave-to {
+    opacity: 0;
+    transform: translate(50px, 0);
+  }
+}
+</style>

--- a/plugins/touchEvent.ts
+++ b/plugins/touchEvent.ts
@@ -1,0 +1,6 @@
+import Vue3TouchEvents from 'vue3-touch-events';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  // @ts-ignore
+  nuxtApp.vueApp.use(Vue3TouchEvents);
+});


### PR DESCRIPTION
需求:

1. 製作手機版新聞文章列表的滑動換頁效果

調整:

1. 使用 vue3-touch-events + vueuse/useSwipe + definePageMeta/pageTransition 製作滑動換頁效果

(1) 僅有手機版，電腦版無此效果

(2) 僅有 /news 與 /magazine 可滑動換頁，文章內頁、雜誌種類頁不可滑動換頁，要使用麵包屑

2. 調整 tab 要依照當前的新聞/雜誌種類、文章切換對應的 active tab

3. 調整 tab 點擊同一個 item 時不會觸發 click fn