### PR TITLE
style(layout-1): 調整登入註冊 layout 底下有空白

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -35,8 +35,7 @@ provide('isPc', isPc);
       padding-top: $mobile-header-height;
     }
 
-    &:not(.login-layout),
-    &:not(.home-layout) {
+    &:not(.login-layout, .home-layout) {
       padding-bottom: 48px;
     }
 
@@ -50,8 +49,7 @@ provide('isPc', isPc);
 @include media-breakpoint-up(md) {
   .layouts,
   ::v-deep(.layouts) {
-    &:not(.login-layout),
-    &:not(.home-layout) {
+    &:not(.login-layout, .home-layout) {
       padding-bottom: 80px;
     }
   }


### PR DESCRIPTION
問題:

1. 登入註冊頁底下有空白

原因:

1. css :not 選擇器語法有誤，導致只用到 :not(.home-layout) 判斷，若要為"且"則要寫在同一個 not 裡面

調整:

1. 將原本分開的 not 寫在一起