### PR TITLE
feat(issue52): 製作雜誌種類列表頁 5-1

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -14,6 +14,7 @@
   </div>
 </template>
 <script setup lang="ts">
+const { getMagazineCategoryList } = useGuestStore();
 const route = useRoute();
 const { width } = useWindowSize();
 const { y } = useWindowScroll();
@@ -26,6 +27,12 @@ const isMobile = computed<boolean>(() => width.value < 768);
 const isPc = computed<boolean>(() => width.value >= 1200);
 provide('isMobile', isMobile);
 provide('isPc', isPc);
+
+onMounted(async () => {
+  await nextTick(() => {
+    getMagazineCategoryList();
+  });
+});
 </script>
 <style lang="scss" scoped>
 @include media-breakpoint-down(md) {

--- a/components/MagazineCategoryCard.vue
+++ b/components/MagazineCategoryCard.vue
@@ -1,7 +1,7 @@
 <template>
   <nuxt-link
-    class="magazine-category-card d-block card text-start text-body-white"
-    :to="`/magazine/${categoryData.categoryName}`"
+    class="magazine-category-card d-block card text-start text-body-white position-relative"
+    :to="`/magazine/${categoryData.categoryId}`"
   >
     <img
       :src="categoryData.categoryImg"
@@ -9,8 +9,11 @@
       :alt="categoryData.categoryDescribe"
     />
     <div class="card-img-overlay">
-      <h4 class="card-title">{{ categoryData.categoryName }}</h4>
-      <p class="card-text">
+      <h4 class="card-title whitespace-nowrap">{{ categoryData.categoryName }}</h4>
+      <p
+        class="card-text"
+        :class="{ 'limit-line-four': isPc && $route.name === 'magazine' }"
+      >
         {{ categoryData.categoryDescribe }}
       </p>
     </div>
@@ -24,6 +27,8 @@ interface NewsCardProps {
 withDefaults(defineProps<NewsCardProps>(), {
   categoryData: () => {}
 });
+
+const isPc = inject('isPc');
 </script>
 <style lang="scss" scoped>
 %transition-duration {
@@ -65,8 +70,35 @@ withDefaults(defineProps<NewsCardProps>(), {
 }
 
 @include media-breakpoint-up(xl) {
+  .card-title {
+    position: absolute;
+    top: 32px;
+    left: 32px;
+    transition: all 0.3s ease-in-out;
+    transform: translate(0, 0);
+  }
+
+  .card-text {
+    opacity: 1;
+    transition: all 0.3s ease-in-out;
+    transform: translateY(41px);
+  }
+
   .magazine-category-card {
     margin: 0 16px;
+
+    &:not(:hover) {
+      .card-title {
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+
+      .card-text {
+        opacity: 0;
+        transform: translateY(80%);
+      }
+    }
   }
 }
 </style>

--- a/components/NFooter.vue
+++ b/components/NFooter.vue
@@ -77,12 +77,16 @@ const footerNav = [
     navTitle: '認識我們',
     linkList: [
       {
-        title: '關於本站',
+        title: '關於我們',
         path: '/about'
       },
       {
-        title: '理念價值',
-        path: '/core-value'
+        title: 'NewsWave 介紹',
+        path: '/'
+      },
+      {
+        title: '方案介紹',
+        path: '/subscription-plan'
       },
       {
         title: '服務條款',
@@ -91,10 +95,6 @@ const footerNav = [
       {
         title: '隱私權政策',
         path: '/privacy-policy'
-      },
-      {
-        title: '方案介紹',
-        path: '/subscription-plan'
       }
     ]
   },

--- a/components/NTabs.vue
+++ b/components/NTabs.vue
@@ -18,6 +18,11 @@
         @click="clickTab(item, index)"
       >
         {{ item.label }}
+        <span
+          v-if="item.badge"
+          class="tab-badge"
+          >{{ item.badge }}</span
+        >
       </li>
     </ul>
     <div
@@ -32,6 +37,7 @@
 export type TabItemType = {
   label: string;
   value: string;
+  badge?: string;
 };
 
 interface NTabsProps {
@@ -109,8 +115,34 @@ watch(
   scroll-behavior: smooth;
 }
 
+@keyframes opacity-frames {
+  0% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.05);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
 .n-tab-item {
   transition: all 0.3s ease-in-out;
+
+  .tab-badge {
+    position: absolute;
+    top: 0;
+    right: 1px;
+    padding: 1px 2px;
+    border-radius: $border-radius-sm;
+    background: $green;
+    color: $gray-100;
+    font-size: 10px;
+    animation: opacity-frames 1.5s ease-in-out infinite;
+  }
 
   &::after {
     position: absolute;

--- a/components/_pages/Home/SelectedMagazine.vue
+++ b/components/_pages/Home/SelectedMagazine.vue
@@ -4,7 +4,7 @@
       <h2 class="text-body-white">精選雜誌</h2>
 
       <n-swiper
-        :swiper-list="categoryList"
+        :swiper-list="magazineCategoryList"
         mode="dark"
       >
         <template #slide="{ slideItem }">
@@ -26,29 +26,8 @@
   </section>
 </template>
 <script lang="ts" setup>
-const { getMagazineCategoryList } = useGuestApi();
-const categoryImg =
-  'https://s3-alpha-sig.figma.com/img/ab7f/370b/4c812551f6d82b1de68bffdd918870d7?Expires=1716768000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=qc5XFY-yjwy0cvxg5QFeYVJjy5dzIwOaCYh3BOOjBjPLJvF5xS7RFqNbDofJZ5kb6bW2ufTfNNiXhArFsqg5knrnpzOtD3iVQQbUyXIrnzIw8nUmmPkpvaWoXr~53UQFi3yKGtSmATPjiON7QXbcKVhqchbYtxHujmcqCRgZq492k-~1ixVwxlXGc9A40dNetDKitNoVgm5yXyfCZ4t-a24b6cgWDkVEXpVAzhdBJ9Fwr9R8XVFeUz2uWFAetCnm4Cy6OlNDCyWZB3LGGMxghdG94Rhn9BHjpdknOhIkp5Ya4Zu5GU75qanbOzB0CI92J5H1OFAljsSEqb6IrHNiYA__';
-
-const categoryList = ref<MagazineCategoryType[]>([]);
-
-const getMagazineCategoryListHandler = async () => {
-  const { status, data } = await getMagazineCategoryList();
-  if (status) {
-    categoryList.value = data.map((e) => ({
-      ...e,
-      categoryImg
-    }));
-  } else {
-    categoryList.value = [];
-  }
-};
-
-onMounted(async () => {
-  await nextTick(() => {
-    getMagazineCategoryListHandler();
-  });
-});
+const guestStore = useGuestStore();
+const { magazineCategoryList } = storeToRefs(guestStore);
 </script>
 
 <style lang="scss" scoped>

--- a/composables/useNav.ts
+++ b/composables/useNav.ts
@@ -83,9 +83,10 @@ const memberSubNav = memberNav.filter((e) => e.childrenRoute?.length);
 const newsNav = ['首頁', '國際', '社會', '科技', '財經', '體育', '娛樂']
   .map((e, index) => ({
     label: e,
-    value: index ? `/news?category=${e}` : '/news'
+    value: index ? `/news?category=${e}` : '/news',
+    badge: ''
   }))
-  .concat({ label: '精選雜誌', value: '/magazine' });
+  .concat({ label: '精選雜誌', value: '/magazine', badge: 'Plus' });
 
 export default () => ({
   memberNav,

--- a/pages/magazine.vue
+++ b/pages/magazine.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="magazine-page">
+    <nuxt-link
+      v-show="!isVip"
+      to="/subscription-plan"
+    >
+      <div
+        class="alert alert-info d-flex align-items-center justify-content-between"
+        role="alert"
+      >
+        <div class="text-sm me-2">NewsWave Plus 享雜誌無限制觀看</div>
+        <img :src="requireImage('icon/arrow-right.svg')" />
+      </div>
+    </nuxt-link>
+
+    <nuxt-page />
+  </div>
+</template>
+
+<script setup lang="ts">
+const userStore = useUserStore();
+const { isVip } = storeToRefs(userStore);
+</script>
+<style lang="scss" scoped>
+.alert {
+  img {
+    width: 8px;
+  }
+}
+</style>

--- a/pages/magazine/index.vue
+++ b/pages/magazine/index.vue
@@ -1,10 +1,14 @@
 <template>
-  <div>
-    <div>雜誌種類列表頁 5-1</div>
-    <h1>精選雜誌</h1>
-    <p>
-      <nuxt-link :to="`/magazine/${category}`">{{ category }}</nuxt-link>
-    </p>
+  <div class="magazine">
+    <div class="row g-4 gx-xl-0">
+      <div
+        v-for="item in magazineCategoryList"
+        :key="item.categoryId"
+        class="col-12 col-sm-6 col-lg-4 col-xl-3"
+      >
+        <magazine-category-card :category-data="item" />
+      </div>
+    </div>
   </div>
 </template>
 <script setup lang="ts">
@@ -16,9 +20,14 @@ definePageMeta({
   keepalive: true
 });
 
-const category = ref('科技前沿周刊');
+const guestStore = useGuestStore();
+const { magazineCategoryList } = storeToRefs(guestStore);
 </script>
 <style lang="scss" scoped>
+::v-deep(.magazine-category-card) {
+  border: 1px solid $gray-300;
+}
+
 @include media-breakpoint-down(md) {
   .slide-left-enter-active,
   .slide-left-leave-active {
@@ -33,6 +42,28 @@ const category = ref('科技前沿周刊');
   .slide-left-leave-to {
     opacity: 0;
     transform: translate(-50px, 0);
+  }
+}
+
+@include media-breakpoint-up(lg) {
+  ::v-deep(.magazine-category-card) {
+    height: 372px;
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  .magazine {
+    margin: 0 -12px;
+  }
+
+  .magazine-category-card {
+    margin: 0 12px;
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  ::v-deep(.magazine-category-card) {
+    height: 250px;
   }
 }
 </style>

--- a/stores/guest.ts
+++ b/stores/guest.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+
+const guestApi = useGuestApi();
+
+export const useGuestStore = defineStore('guest', {
+  state: () => ({
+    magazineCategoryList: [] as MagazineCategoryType[]
+  }),
+  actions: {
+    async getMagazineCategoryList() {
+      const { data, status } = await guestApi.getMagazineCategoryList();
+      if (status) {
+        const categoryImg = 'https://cdn.pixabay.com/photo/2018/09/16/00/27/magazine-3680550_1280.jpg';
+        this.magazineCategoryList = data.map((e) => ({
+          ...e,
+          categoryImg: e.categoryImg || categoryImg
+        }));
+      } else {
+        this.magazineCategoryList = [];
+      }
+    }
+  }
+});
+
+export default {};


### PR DESCRIPTION
需求:

1. 製作雜誌種類列表頁 5-1 畫面

調整:

1. 將取得雜誌種類的 api 改放在 app.vue，取得資料後存放在 store，讓首頁跟雜誌頁都 可以從 store 利用

2. 精選雜誌的 tab 加上 plus 標籤吸引使用者點擊

3. 調整 MagazineCategoryCard 電腦版樣式交互，hover 後才出現雜誌介紹

4. 加上預設雜誌封面圖片

5. 調整 footer nav 內容