### PR TITLE
style(defaultLayout): 調整非新聞、雜誌種類頁的頁面內容寬度

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,7 +16,7 @@
       </section>
       <section
         v-else
-        class="col-12 col-lg-9"
+        class="col-12"
       >
         <slot />
       </section>


### PR DESCRIPTION
調整:

1. 移除 col-lg-9，維持滿版