### PR TITLE
feat(issue50): 訂閱串接金流

### DIFF
--- a/components/Header/Avatar/AvatarDropdown.vue
+++ b/components/Header/Avatar/AvatarDropdown.vue
@@ -104,7 +104,7 @@ const logoutHandler = async () => {
 
     if (route.path?.startsWith('/member')) {
       navigateTo('/news');
-    } else if (route.name === 'subscription-plan-checkout') {
+    } else if (String(route.name)?.includes('subscription-plan-checkout')) {
       navigateTo('/subscription-plan');
     }
   } else {

--- a/components/_pages/subscription-plan/PlanSelection.vue
+++ b/components/_pages/subscription-plan/PlanSelection.vue
@@ -1,74 +1,79 @@
 <template>
   <div class="plan-selection row justify-content-center text-center">
-    <div
-      v-for="item in renderPlanList"
-      :id="`${item.type}Plan`"
-      :key="item.title"
-      class="col-12 col-xl-4"
-      :class="{ 'col-lg-5': !isIntroMode }"
-    >
+    <client-only>
       <div
-        class="card mb-4 px-0 mx-auto overflow-hidden"
-        :class="{ 'select-card cursor-pointer': !isIntroMode, 'select-card-active': item.type === selectedPlan?.type }"
-        @click="selectPlanHandler(item)"
+        v-for="item in renderPlanList"
+        :id="`${item.type}Plan`"
+        :key="item.title"
+        class="col-12 col-xl-4"
+        :class="{ 'col-lg-5': !isIntroMode }"
       >
-        <div class="card-header pt-3 pb-4 bg-primary fw-bold position-relative">
-          <h4 class="plan-title">{{ item.title }}</h4>
-          <h5 class="text-blue-400 mb-0">
-            $
-            <span class="plan-price text-body-white px-1">{{ item.price }}</span>
-            /月
-          </h5>
-          <div
-            v-if="item.recommend"
-            class="recommend-label d-flex align-items-center rounded-1 text-body-white position-absolute"
-          >
-            <img
-              class="me-1"
-              :src="requireImage('icon/ship-anchor.svg')"
-            />
-            <span>推薦</span>
-          </div>
-          <img
-            :class="{ 'checked-icon-show': item.type === selectedPlan?.type }"
-            class="checked-icon position-absolute"
-            :src="requireImage('icon/checked.svg')"
-          />
-        </div>
-        <div class="card-content pt-4">
-          <div class="card-body">
-            <ul class="access-list">
-              <li
-                v-for="access in item.accessList"
-                :key="access.value"
-                class="access-list-item fs-5 mb-3"
-              >
-                <div class="d-flex align-items-center justify-content-center">
-                  <img
-                    class="me-2"
-                    :src="requireImage(`icon/${access.value}.svg`)"
-                  />
-                  <span :class="{ 'text-accent': access.value === 'discount' }"> {{ access.label }}</span>
-                </div>
-              </li>
-            </ul>
+        <div
+          class="card mb-4 px-0 mx-auto overflow-hidden"
+          :class="{
+            'select-card cursor-pointer': !isIntroMode,
+            'select-card-active': item.type === selectedPlan?.type
+          }"
+          @click="selectPlanHandler(item)"
+        >
+          <div class="card-header pt-3 pb-4 bg-primary fw-bold position-relative">
+            <h4 class="plan-title">{{ item.title }}</h4>
+            <h5 class="text-blue-400 mb-0">
+              $
+              <span class="plan-price text-body-white px-1">{{ item.price }}</span>
+              /月
+            </h5>
             <div
-              v-show="isIntroMode"
-              class="px-4 mb-3"
-              :class="{ 'current-hint': item.isCurrentPlan }"
+              v-if="item.recommend"
+              class="recommend-label d-flex align-items-center rounded-1 text-body-white position-absolute"
             >
-              <n-button
-                class="w-100"
-                :text="item.btnText"
-                :color="item.btnColor"
-                @click="goToPage(item)"
+              <img
+                class="me-1"
+                :src="requireImage('icon/ship-anchor.svg')"
               />
+              <span>推薦</span>
             </div>
+            <img
+              :class="{ 'checked-icon-show': item.type === selectedPlan?.type }"
+              class="checked-icon position-absolute"
+              :src="requireImage('icon/checked.svg')"
+            />
           </div>
-          <img :src="requireImage('subscription-plan/bottom-wave.svg')" />
+          <div class="card-content pt-4">
+            <div class="card-body">
+              <ul class="access-list">
+                <li
+                  v-for="access in item.accessList"
+                  :key="access.value"
+                  class="access-list-item fs-5 mb-3"
+                >
+                  <div class="d-flex align-items-center justify-content-center">
+                    <img
+                      class="me-2"
+                      :src="requireImage(`icon/${access.value}.svg`)"
+                    />
+                    <span :class="{ 'text-accent': access.value === 'discount' }"> {{ access.label }}</span>
+                  </div>
+                </li>
+              </ul>
+              <div
+                v-show="isIntroMode"
+                class="px-4 mb-3"
+                :class="{ 'current-hint': item.isCurrentPlan }"
+              >
+                <n-button
+                  class="w-100"
+                  :text="item.btnText"
+                  :color="item.btnColor"
+                  @click="goToPage(item)"
+                />
+              </div>
+            </div>
+            <img :src="requireImage('subscription-plan/bottom-wave.svg')" />
+          </div>
         </div>
       </div>
-    </div>
+    </client-only>
     <Teleport to="body">
       <auth-hint-modal v-model:visible="showHintModal" />
     </Teleport>
@@ -97,9 +102,7 @@ const token = useCookie('token');
 const userStore = useUserStore();
 const route = useRoute();
 
-const { isVip } = storeToRefs(userStore);
-
-const currentStatus = '';
+const { isVip, planType } = storeToRefs(userStore);
 
 const accessList = [
   {
@@ -144,7 +147,7 @@ const renderPlanList = computed(() =>
         btnColor: (!redirect || redirect.startsWith('/subscription-plan') ? 'purchase' : 'secondary') as
           | 'purchase'
           | 'secondary',
-        isCurrentPlan: currentStatus === e.type || (e.type === 'free' && !isVip.value && token.value)
+        isCurrentPlan: planType.value === e.type || (e.type === 'free' && !isVip.value && token.value)
       };
     })
     .filter((e) => props.showFree || e.type !== 'free')

--- a/composables/useOrderApi.ts
+++ b/composables/useOrderApi.ts
@@ -13,14 +13,6 @@ class orderApi {
 
     return res;
   }
-
-  // static async logout(): Promise<ApiResponseType<undefined>> {
-  //   const res = await useApi('/order/payment-results', {
-  //     method: 'post'
-  //   });
-
-  //   return res;
-  // }
 }
 
 export default () => orderApi;

--- a/composables/useUserApi.ts
+++ b/composables/useUserApi.ts
@@ -35,6 +35,22 @@ class userApi {
     return res;
   }
 
+  static async getUserInfo(userId: UserInfoType['id']): Promise<ApiResponseType<UserInfoType>> {
+    const res = await useApi(`/user/info/${userId}`, {
+      method: 'get'
+    });
+
+    return res;
+  }
+
+  static async getUserData(userId: UserInfoType['id']): Promise<ApiResponseType<UserDataType>> {
+    const res = await useApi(`/user/data/${userId}`, {
+      method: 'get'
+    });
+
+    return res;
+  }
+
   static async updatePassword(params: { [key: string]: PasswordType }): Promise<ApiResponseType<undefined>> {
     const body = {
       oldPassword: params.oldPassword,
@@ -43,6 +59,18 @@ class userApi {
     const res = await useApi('/user/password', {
       method: 'patch',
       body
+    });
+
+    return res;
+  }
+
+  static async getSubscriptionList(query: TransactionIdType): Promise<ApiResponseType<SubscriptionOrderType[]>> {
+    const params = {
+      transactionId: query.transactionId
+    };
+    const res = await useApi('/user/subscription', {
+      method: 'get',
+      params
     });
 
     return res;

--- a/pages/login-register/index.vue
+++ b/pages/login-register/index.vue
@@ -219,8 +219,8 @@ const submit = async () => {
       id: 'login-success',
       message
     });
-
     await goBack();
+    await userStore.getUserData();
   } else {
     warnMessage.value = message;
   }

--- a/pages/subscription-plan/checkout/orderResult.vue
+++ b/pages/subscription-plan/checkout/orderResult.vue
@@ -1,25 +1,121 @@
 <template>
-  <div class="order-result text-center">
-    <h5>假的訂單編號: 123456789</h5>
-    <p class="text-center">假的付款結果: {{ orderStatus ? '成功' : '尚未完成' }}</p>
-  </div>
-  <div class="btn-container">
-    <n-button
-      v-show="!orderStatus"
-      size="lg"
-      class="flex-fill mx-auto"
-      type="outline"
-      text="聯絡我們"
-      @click="navigateTo('/contact-us')"
-    />
-    <n-button
-      size="lg"
-      class="flex-fill mx-auto"
-      text="返回首頁"
-      @click="navigateTo('/news')"
-    />
+  <div class="order-result">
+    <div
+      class="card"
+      :class="{ 'justify-content-center align-items-center': pageLoading }"
+    >
+      <n-spin
+        v-if="pageLoading"
+        class="text-primary"
+      />
+      <template v-else>
+        <div class="card-body py-0">
+          <div class="pay-status pt-3 pt-md-4 mb-md-2 d-flex flex-column align-items-center gap-3 gap-md-4">
+            <img :src="requireImage(`icon/${isPaid ? 'checked' : 'warning'}.svg`)" />
+            <h3 class="text-center mb-0">{{ renderText }}</h3>
+          </div>
+          <ul>
+            <li
+              v-for="(item, index) in orderItemList"
+              :key="item.title"
+              class="py-3"
+              :class="{ 'border-top': index }"
+            >
+              <div class="d-flex justify-content-between align-items-center gap-2">
+                <div class="whitespace-nowrap">{{ item.title }}</div>
+                <div class="text-end break-word">
+                  {{ item.value }}
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </template>
+    </div>
+    <div class="btn-container">
+      <n-button
+        v-show="!isPaid"
+        size="lg"
+        class="flex-fill mx-auto"
+        type="outline"
+        text="聯絡我們"
+        @click="navigateTo('/contact-us')"
+      />
+      <n-button
+        size="lg"
+        class="flex-fill mx-auto"
+        text="返回首頁"
+        @click="navigateTo('/news')"
+      />
+    </div>
   </div>
 </template>
 <script lang="ts" setup>
-const orderStatus = ref<boolean>(false);
+const route = useRoute();
+
+const { getUserData } = useUserStore();
+const { getSubscriptionList } = useUserApi();
+
+const pageLoading = ref<boolean>(true);
+const subscriptionInfo = ref<SubscriptionOrderType>({});
+
+const isPaid = computed<boolean>(() => subscriptionInfo.value?.payStatus === 'paid');
+
+const renderText = computed(() => {
+  if (isPaid.value) {
+    return '付款成功';
+  }
+  return subscriptionInfo.value?.transactionId ? '未完成付款，請再重試一次' : '無此訂單編號';
+});
+
+const getSubscriptionListHandler = async () => {
+  const params = {
+    transactionId: route.query?.order as TransactionIdType['transactionId']
+  };
+  const { status, data } = await getSubscriptionList(params);
+  if (status && data.length) {
+    [subscriptionInfo.value] = data;
+    getUserData();
+  }
+  setTimeout(() => {
+    pageLoading.value = false;
+  }, 300);
+};
+
+const orderItemList = computed(() => [
+  {
+    title: '訂單編號',
+    value: subscriptionInfo.value?.transactionId || '-'
+  },
+  {
+    title: '方案名稱',
+    value: subscriptionInfo.value?.itemName || '-'
+  },
+  {
+    title: '總計',
+    value: `${subscriptionInfo.value?.total || 0} NTD`
+  }
+]);
+
+onMounted(async () => {
+  pageLoading.value = true;
+  await nextTick(() => {
+    getSubscriptionListHandler();
+  });
+});
 </script>
+<style lang="scss" scoped>
+.order-result .card {
+  min-height: 350px;
+}
+
+.pay-status img {
+  width: 80px;
+}
+
+@include media-breakpoint-up(md) {
+  .pay-status img {
+    width: 120px;
+  }
+}
+</style>

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -1,20 +1,36 @@
 import { defineStore } from 'pinia';
 
+const userApi = useUserApi();
+
 export const useUserStore = defineStore('user', {
   state: () => ({
     id: '',
     name: '',
     email: '',
-    isVip: false,
-    avatar: ''
+    birthday: '',
+    gender: '',
+    avatar: '',
+    isVip: '',
+    subscribeExpiredAt: '',
+    planType: ''
   }),
+
   actions: {
     SET_USER_INFO(value: UserInfoType): void {
       Object.entries(value || {}).forEach(([key, val]) => {
         this[key as keyof UserInfoType] = val;
       });
+    },
+    async getUserData() {
+      const { data, status } = await userApi.getUserData(this.id);
+      if (status) {
+        Object.entries(data || {}).forEach(([key, val]) => {
+          this[key as keyof UserDataType] = val;
+        });
+      }
     }
   },
+
   persist: {
     storage: persistedState.localStorage
   }

--- a/types/apiType.ts
+++ b/types/apiType.ts
@@ -1,6 +1,6 @@
 declare global {
   interface ApiResponseType<T> {
-    status?: boolean;
+    status: boolean;
     message: string;
     data: T;
   }

--- a/types/userType.ts
+++ b/types/userType.ts
@@ -7,10 +7,31 @@ declare global {
     id: string;
     name: string;
     email: string;
+    birthday: string;
+    gender: string;
   }
 
-  interface UserStatusType {
+  interface UserDataType {
     isVip: boolean;
+    avatar: string;
+    subscribeExpiredAt: string;
+    planType: string;
+  }
+
+  interface TransactionIdType {
+    transactionId?: string;
+  }
+
+  interface SubscriptionOrderType extends TransactionIdType {
+    planType?: 'month' | 'year';
+    itemName?: string;
+    total?: number;
+    payStatus?: 'paid' | 'fail' | 'unpaid';
+    createdAt?: string;
+    updatedAt?: string;
+    orderAt?: string;
+    paidAt?: string;
+    subscribeExpiredAt?: string;
   }
 }
 


### PR DESCRIPTION
需求:

1. 完成表單串接金流

調整:

1. 製作第三步付款結果頁面，由於從綠界返回此網址，會先依據訂單編號 call API 確認訂單狀態

2. call /user/data 更新用戶訂閱狀態

3. 新增相關的 api 與 types

4. 調整交互，登入、註冊成功時也要取得訂閱狀態