### PR TITLE
fix(homeHeader-1): 修正電腦版下滑時，header 背景色動效會閃一下

### DIFF
--- a/components/Header/HomeHeader.vue
+++ b/components/Header/HomeHeader.vue
@@ -4,11 +4,8 @@
     :class="{ 'bg-primary-gradient': isNavExpanded }"
   >
     <nav
-      class="navbar navbar-expand-md position-relative"
-      :class="[
-        isPcScrollDown ? 'scroll-down' : 'bg-primary-gradient bg-md-transparent',
-        { 'is-expand': isNavExpanded }
-      ]"
+      class="navbar navbar-expand-md position-relative bg-md-transparent"
+      :class="[isPcScrollDown ? 'scroll-down' : 'bg-primary-gradient', { 'is-expand': isNavExpanded }]"
     >
       <div class="container-fluid px-3 px-xl-5 position-relative z-1">
         <n-logo logo-type="light" />


### PR DESCRIPTION
問題:

1. 此 commit feat(home) 的延伸問題，電腦版下滑時可看到 header 背景色會先閃一下白灰色才變成深藍色漸層

原因:

1. .navbar 預設有一個 background-image 透明漸層

調整:

1. 將 navbar 設定為 background-image: transparent