### PR TITLE
style(footerLayout):  調整 footer layout

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -65,6 +65,7 @@ onMounted(async () => {
   ::v-deep(.layouts) {
     &:not(.login-layout, .home-layout) {
       padding-bottom: 80px;
+      min-height: calc(100vh - $pc-header-tab-height - 372px);
     }
   }
 }

--- a/assets/scss/config/_variables.scss
+++ b/assets/scss/config/_variables.scss
@@ -2,10 +2,10 @@
 // consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
 
 // Header
-$header-tab-height: 40px;
+$header-tab-height: 41px;
 $mobile-header-height: 56px;
 $mobile-header-tab-height: calc($mobile-header-height + $header-tab-height);
-$pc-header-height: 78px;
+$pc-header-height: 72px;
 $pc-header-tab-height: calc($pc-header-height + $header-tab-height);
 
 // Color system

--- a/components/Header/NHeader.vue
+++ b/components/Header/NHeader.vue
@@ -16,22 +16,3 @@ const getComponent = computed(() => {
   }
 });
 </script>
-<style lang="scss" scoped>
-::v-deep(.home-header) {
-  height: $mobile-header-height;
-}
-
-::v-deep(.other-header) {
-  height: $mobile-header-tab-height;
-}
-
-@include media-breakpoint-up(md) {
-  ::v-deep(.home-header) {
-    height: $mobile-header-tab-height;
-  }
-
-  ::v-deep(.other-header) {
-    height: $pc-header-tab-height;
-  }
-}
-</style>


### PR DESCRIPTION
原因:

1. 讓電腦版 footer 可以置底，手機版 footer 很高故不需要調整

調整:

1. 使用 calc 計算 layout 容器最小高度為 100vh - header 高 -  footer 高

2. 調整變數，tab 加上 1px 為底線，調整電腦版 header 高度

3. 移除 nHeader 內用不到的 style