### PR TITLE
fix(userAuth): 修正需要 token 判斷的邏輯

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -29,14 +29,16 @@ provide('isMobile', isMobile);
 provide('isPc', isPc);
 
 const token: any = useCookie('token');
-const { getUserData } = useUserStore();
+const userStore = useUserStore();
 
 onMounted(async () => {
   await nextTick(() => {
     getMagazineCategoryList();
 
     if (token.value) {
-      getUserData();
+      userStore.getUserData();
+    } else {
+      userStore.$reset();
     }
   });
 });

--- a/pages/magazine.vue
+++ b/pages/magazine.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="magazine-page">
     <nuxt-link
-      v-show="!isVip"
+      v-show="!(token && isVip)"
       to="/subscription-plan"
     >
       <div
@@ -18,6 +18,7 @@
 </template>
 
 <script setup lang="ts">
+const token: any = useCookie('token');
 const userStore = useUserStore();
 const { isVip } = storeToRefs(userStore);
 </script>


### PR DESCRIPTION
問題:

1. 未登入時，雜誌頁少了 NewsWave Plan cta banner

原因:

1. cookie 的 token 已失效，localStorage 內卻還有前一個會員的資料

調整:

1. app.vue 加上判斷，若沒 token 要 reset user store

2. 雜誌頁 cta banner 加上 token 判斷防呆