### PR TITLE
feat(nBreadcrumb): 新增麵包屑元件

### DIFF
--- a/assets/scss/config/_variables.scss
+++ b/assets/scss/config/_variables.scss
@@ -1582,14 +1582,14 @@ $figure-caption-color: var(--#{$prefix}secondary-color) !default;
 // Breadcrumbs
 
 // scss-docs-start breadcrumb-variables
-$breadcrumb-font-size: null !default;
+$breadcrumb-font-size: $font-size-sm !default;
 $breadcrumb-padding-y: 0 !default;
 $breadcrumb-padding-x: 0 !default;
 $breadcrumb-item-padding-x: 0.5rem !default;
 $breadcrumb-margin-bottom: 1rem !default;
 $breadcrumb-bg: null !default;
-$breadcrumb-divider-color: var(--#{$prefix}secondary-color) !default;
-$breadcrumb-active-color: var(--#{$prefix}secondary-color) !default;
+$breadcrumb-divider-color: $blue-300 !default;
+$breadcrumb-active-color: $blue-300 !default;
 $breadcrumb-divider: '/' !default;
 $breadcrumb-divider-flipped: $breadcrumb-divider !default;
 $breadcrumb-border-radius: null !default;

--- a/components/Header/OtherHeader.vue
+++ b/components/Header/OtherHeader.vue
@@ -74,7 +74,7 @@ const currentTab = ref<TabItemType['label']>('');
 const isMemberCenter = computed(() => route.path.startsWith('/member'));
 const isSubscriptionPage = computed(() => route.path.startsWith('/subscription-plan'));
 
-const changeTab = (tabItem: any) => {
+const changeTab = (tabItem: NavItemWithSubType) => {
   if (isMemberCenter.value) {
     if (tabItem.children) {
       navigateTo({ name: tabItem.children });
@@ -86,7 +86,7 @@ const changeTab = (tabItem: any) => {
   }
 };
 
-const tabList = computed(() => (isMemberCenter.value ? memberNav : newsNav));
+const tabList = computed<NavItemWithSubType[] | NavItemType[]>(() => (isMemberCenter.value ? memberNav : newsNav));
 
 watchEffect(() => {
   if (isMemberCenter.value) {

--- a/components/NAccordion.vue
+++ b/components/NAccordion.vue
@@ -37,13 +37,13 @@
   </div>
 </template>
 <script setup lang="ts">
-export type accordionItem = {
+export type AccordionItem = {
   title: string;
   content: string;
 };
 
 interface NAccordionProps {
-  accordionList?: accordionItem[];
+  accordionList?: AccordionItem[];
 }
 
 withDefaults(defineProps<NAccordionProps>(), {

--- a/components/NBreadcrumb.vue
+++ b/components/NBreadcrumb.vue
@@ -1,0 +1,68 @@
+<template>
+  <nav
+    v-if="breadcrumbList.length"
+    aria-label="breadcrumb"
+  >
+    <ol class="breadcrumb d-none d-md-flex">
+      <li
+        v-for="item in breadcrumbList"
+        :key="item?.label"
+        class="breadcrumb-item"
+        :class="{
+          'text-decoration-underline is-btn': !item?.current,
+          active: item?.current
+        }"
+      >
+        <nuxt-link
+          v-if="!item?.current"
+          :to="item?.value"
+        >
+          {{ item?.label }}
+        </nuxt-link>
+        <span v-else>{{ item?.label }}</span>
+      </li>
+    </ol>
+    <nuxt-link
+      class="d-flex align-items-center d-md-none mobile-breadcrumb-item"
+      :to="prevRoute?.value"
+    >
+      <img :src="requireImage('icon/arrow-top.svg')" />
+      <span class="text-sm text-decoration-underline text-primary">{{ prevRoute?.label }}</span>
+    </nuxt-link>
+  </nav>
+</template>
+<script lang="ts" setup>
+interface NBreadcrumbType extends NavItemType {
+  current?: boolean;
+  prev?: boolean;
+}
+
+const guestStore = useGuestStore();
+const { breadcrumbNav } = storeToRefs(guestStore);
+
+const breadcrumbList = ref<NBreadcrumbType[]>([]);
+
+const prevRoute = computed(() => breadcrumbList.value?.find((e) => e.prev));
+
+watchImmediate(
+  () => breadcrumbNav.value,
+  (val: NBreadcrumbType[]) => {
+    breadcrumbList.value = JSON.parse(JSON.stringify(val || []));
+
+    breadcrumbList.value.forEach((e, index, arr) => {
+      e.current = index === arr.length - 1;
+      e.prev = index === arr.length - 2;
+    });
+  }
+);
+</script>
+<style lang="scss" scoped>
+.mobile-breadcrumb-item {
+  img {
+    padding: 7px 0;
+    width: 22px;
+    height: 22px;
+    transform: rotate(-90deg);
+  }
+}
+</style>

--- a/components/_pages/Home/HomeFaq.vue
+++ b/components/_pages/Home/HomeFaq.vue
@@ -24,9 +24,9 @@
   </section>
 </template>
 <script setup lang="ts">
-import type { accordionItem } from '@/components/NAccordion.vue';
+import type { AccordionItem } from '@/components/NAccordion.vue';
 
-const list = ref<accordionItem[]>([
+const list = ref<AccordionItem[]>([
   {
     title: 'NewsWave 是什麼？',
     content:

--- a/components/_pages/subscription-plan/PlanFaq.vue
+++ b/components/_pages/subscription-plan/PlanFaq.vue
@@ -5,9 +5,9 @@
   />
 </template>
 <script setup lang="ts">
-import type { accordionItem } from '@/components/NAccordion.vue';
+import type { AccordionItem } from '@/components/NAccordion.vue';
 
-const list = ref<accordionItem[]>([
+const list = ref<AccordionItem[]>([
   {
     title: 'NewsWave Plus 是什麼？',
     content:

--- a/composables/useNav.ts
+++ b/composables/useNav.ts
@@ -1,4 +1,4 @@
-const memberNav = [
+const memberNav: NavItemWithSubType[] = [
   {
     label: '會員中心',
     value: ''
@@ -80,7 +80,7 @@ const memberNav = [
 
 const memberSubNav = memberNav.filter((e) => e.childrenRoute?.length);
 
-const newsNav = ['首頁', '國際', '社會', '科技', '財經', '體育', '娛樂']
+const newsNav: NavItemType[] = ['首頁', '國際', '社會', '科技', '財經', '體育', '娛樂']
   .map((e, index) => ({
     label: e,
     value: index ? `/news?category=${e}` : '/news',

--- a/layouts/member.vue
+++ b/layouts/member.vue
@@ -16,6 +16,7 @@
         </nuxt-link>
       </nav>
       <div class="pt-3 pt-md-4">
+        <n-breadcrumb class="mb-2" />
         <slot />
       </div>
     </client-only>
@@ -23,12 +24,41 @@
 </template>
 
 <script lang="ts" setup>
-const { memberSubNav } = useNav();
+const { newsNav, memberSubNav } = useNav();
 const route = useRoute();
 
 const currentChildrenRoute = computed(() => {
   if (String(route.name) === 'member') return [];
   return memberSubNav?.find((e) => String(route.name)?.includes(e.value))?.childrenRoute || [];
+});
+
+const guestStore = useGuestStore();
+
+watchImmediate(
+  () => route.path,
+  () => {
+    if (route?.matched?.length) {
+      const list: NavItemType[] = newsNav
+        .filter((e) => e.label === '首頁')
+        .concat({
+          label: '會員中心',
+          value: '/member'
+        });
+
+      if (route.name !== 'member') {
+        const subItem = route?.matched?.[1];
+        list.push({
+          label: (subItem?.meta?.title as string) || '',
+          value: ''
+        });
+      }
+      guestStore.SET_BREADCRUMB_NAV(list);
+    }
+  }
+);
+
+onUnmounted(() => {
+  guestStore.SET_BREADCRUMB_NAV([]);
 });
 </script>
 <style lang="scss" scoped>

--- a/pages/article/[category]/[articleId].vue
+++ b/pages/article/[category]/[articleId].vue
@@ -10,7 +10,17 @@
 const route = useRoute();
 const token: any = useCookie('token');
 
+const guestStore = useGuestStore();
+const { magazineCategoryList } = storeToRefs(guestStore);
+
 const articleType = computed(() => (route.params.articleId[0] === 'M' ? '雜誌' : '新聞'));
 
 const hiddenArticle = computed(() => !token.value && articleType.value === '雜誌');
+
+watchImmediate([() => route.path, () => magazineCategoryList.value], () => {
+  const list = renderBreadcrumb();
+  list.push({ label: '假的 title 標題標題的 title 標題標題的 title 標題標題', value: '' });
+
+  guestStore.SET_BREADCRUMB_NAV(list);
+});
 </script>

--- a/pages/member/account/basic.vue
+++ b/pages/member/account/basic.vue
@@ -1,3 +1,8 @@
 <template>
   <div>帳密資料 6-2</div>
 </template>
+<script setup lang="ts">
+definePageMeta({
+  title: '帳戶管理 - 修改個人資料'
+});
+</script>

--- a/pages/member/account/password.vue
+++ b/pages/member/account/password.vue
@@ -60,6 +60,10 @@
   </form>
 </template>
 <script lang="ts" setup>
+definePageMeta({
+  title: '帳戶管理 - 修改密碼'
+});
+
 const { updatePassword } = useUserApi();
 
 interface PasswordFieldType {

--- a/pages/member/article/collect.vue
+++ b/pages/member/article/collect.vue
@@ -1,3 +1,8 @@
 <template>
   <div>我的收藏 6-7</div>
 </template>
+<script lang="ts" setup>
+definePageMeta({
+  title: '文章管理 - 我的收藏'
+});
+</script>

--- a/pages/member/article/comment.vue
+++ b/pages/member/article/comment.vue
@@ -1,3 +1,8 @@
 <template>
   <div>我的留言 6-8</div>
 </template>
+<script lang="ts" setup>
+definePageMeta({
+  title: '文章管理 - 我的留言'
+});
+</script>

--- a/pages/member/article/follow.vue
+++ b/pages/member/article/follow.vue
@@ -1,3 +1,8 @@
 <template>
   <div>我的追蹤 6-6</div>
 </template>
+<script lang="ts" setup>
+definePageMeta({
+  title: '文章管理 - 我的追蹤'
+});
+</script>

--- a/pages/member/index.vue
+++ b/pages/member/index.vue
@@ -39,4 +39,8 @@ const userStore = useUserStore();
 const { id, name, email } = storeToRefs(userStore);
 
 const nTabsBus = useEventBus('nTabsBus');
+
+definePageMeta({
+  title: '會員中心'
+});
 </script>

--- a/pages/member/notification/announcement.vue
+++ b/pages/member/notification/announcement.vue
@@ -1,3 +1,8 @@
 <template>
   <div>最新公告 6-10</div>
 </template>
+<script setup lang="ts">
+definePageMeta({
+  title: '通知中心 - 最新公告'
+});
+</script>

--- a/pages/member/notification/personal.vue
+++ b/pages/member/notification/personal.vue
@@ -1,3 +1,8 @@
 <template>
   <div>我的通知</div>
 </template>
+<script setup lang="ts">
+definePageMeta({
+  title: '通知中心 - 我的通知'
+});
+</script>

--- a/pages/member/subscription/info.vue
+++ b/pages/member/subscription/info.vue
@@ -48,6 +48,10 @@
   </div>
 </template>
 <script lang="ts" setup>
+definePageMeta({
+  title: '訂閱管理 - 訂閱資訊'
+});
+
 const userStore = useUserStore();
 
 const { planList } = usePlanList();

--- a/pages/member/subscription/order.vue
+++ b/pages/member/subscription/order.vue
@@ -7,6 +7,10 @@
 <script lang="ts" setup>
 import type { ColumnItemType } from '@/components/NTableList.vue';
 
+definePageMeta({
+  title: '訂閱管理 - 訂單記錄'
+});
+
 const { getSubscriptionList } = useUserApi();
 
 const tableColumn: ColumnItemType[] = [

--- a/stores/guest.ts
+++ b/stores/guest.ts
@@ -4,9 +4,13 @@ const guestApi = useGuestApi();
 
 export const useGuestStore = defineStore('guest', {
   state: () => ({
-    magazineCategoryList: [] as MagazineCategoryType[]
+    magazineCategoryList: [] as MagazineCategoryType[],
+    breadcrumbNav: [] as NavItemType[]
   }),
   actions: {
+    SET_BREADCRUMB_NAV(value: NavItemType[]) {
+      this.breadcrumbNav = value;
+    },
     async getMagazineCategoryList() {
       const { data, status } = await guestApi.getMagazineCategoryList();
       if (status) {

--- a/types/navType.ts
+++ b/types/navType.ts
@@ -1,0 +1,14 @@
+declare global {
+  interface NavItemType {
+    label: string;
+    value: string;
+    badge?: string;
+  }
+
+  interface NavItemWithSubType extends NavItemType {
+    children?: NavItemType['value'];
+    childrenRoute?: NavItemType[];
+  }
+}
+
+export {};

--- a/utils/renderBreadcrumb.ts
+++ b/utils/renderBreadcrumb.ts
@@ -1,0 +1,27 @@
+export default (): NavItemType[] => {
+  const route = useRoute();
+  const { newsNav } = useNav();
+  const guestStore = useGuestStore();
+  const { magazineCategoryList } = storeToRefs(guestStore);
+
+  let list: NavItemType[] = [];
+
+  const { category = '' } = route.name === 'news' ? route.query : route.params;
+
+  // 新聞
+  if (category !== '首頁' && newsNav.some((e) => e.label === String(category))) {
+    list = newsNav.filter((e) => e.label === '首頁' || e.label === String(category));
+    // 雜誌
+  } else if (magazineCategoryList.value?.some((e) => e.categoryId === String(category))) {
+    list = newsNav.filter((e) => e.label === '精選雜誌');
+    const magazineItem = magazineCategoryList.value?.find((e) => e.categoryId === String(category));
+    list.push({
+      label: magazineItem?.categoryName || '',
+      value: `/magazine/${magazineItem?.categoryId}`
+    });
+  } else {
+    list = [];
+  }
+
+  return list;
+};


### PR DESCRIPTION
需求:

1. 新增麵包屑，目前用在 default layout(新聞、雜誌、文章)、member layout (會員中心)

調整:

1. 調整 bs breadcrumb 變數

2. 新增相關 type，麵包屑跟 nav type 基本上一樣

3. 利用 store 管理麵包屑列表

4. 麵包屑樣式依據設計師 https://www.notion.so/942a307a4ce543fcb34a206796bac7c1 回覆，電腦板顯示全部的路由，手機版只顯示箭頭 + 上一層路由

5. default layout 因為每頁的父 route 會有所不同，故寫 renderBreadcrumb tuils 管理處理邏輯

6. member layout 利用 route matched meta (設定definePageMeta) 處理麵包屑列表