### PR TITLE
refactor(isVip): 調整 user store 內的 isVip

### DIFF
--- a/pages/member/notification/personal.vue
+++ b/pages/member/notification/personal.vue
@@ -21,8 +21,8 @@ onMounted(() => {
       userId: id.value
     }
   });
-  socket.on('notice', (data) => {
-    if (data.action !== 'create') return;
+  socket.on('notice', (data: any) => {
+    if (data?.action !== 'create') return;
     notice.value = data;
     console.log('notice:', notice.value);
   });

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -10,11 +10,14 @@ export const useUserStore = defineStore('user', {
     birthday: '',
     gender: '',
     avatar: '',
-    isVip: '',
     subscribeExpiredAt: '',
     planType: '',
     autoRenew: ''
   }),
+
+  getters: {
+    isVip: (state) => state.planType === 'month' || state.planType === 'year'
+  },
 
   actions: {
     SET_USER_INFO(value: UserInfoType): void {

--- a/types/userType.ts
+++ b/types/userType.ts
@@ -12,7 +12,6 @@ declare global {
   }
 
   interface UserDataType {
-    isVip: boolean;
     avatar: string;
     subscribeExpiredAt: string;
     planType: PlanItem['type'];


### PR DESCRIPTION
原因:

1. 後端改成只會給 planType 讓前端知道該用戶是否為訂閱用戶，移除 isVip 欄位

調整:

1. 前端 isVip 改成利用 planType 寫成  getters 的方式判斷