### PR TITLE
feat(pressEnter): 新增按下 enter 即可送出表單功能

### DIFF
--- a/components/NInput.vue
+++ b/components/NInput.vue
@@ -9,6 +9,7 @@
       class="form-control text-sm py-2"
       :class="{ 'invalid-field': hasError, 'has-suffix-icon': suffixIcon }"
       :disabled="disabled"
+      @keyup.enter="$emit('pressEnter')"
     />
     <div
       v-if="suffixIcon"
@@ -44,6 +45,8 @@ withDefaults(defineProps<NInputProps>(), {
   suffixIcon: '',
   suffixIconClickFn: undefined
 });
+
+defineEmits<{ (e: 'pressEnter'): void }>();
 </script>
 <style lang="scss" scoped>
 .n-input {

--- a/pages/login-register/index.vue
+++ b/pages/login-register/index.vue
@@ -39,6 +39,7 @@
                 v-model:value="formState[field.value]"
                 :placeholder="`請輸入${field.label}`"
                 :has-error="!!errorMessage[field.value]"
+                @press-enter="submit"
               />
               <n-input
                 v-else
@@ -46,6 +47,7 @@
                 v-model:value="formState[field.value]"
                 :placeholder="`請輸入${field.label}`"
                 :has-error="!!errorMessage[field.value]"
+                @press-enter="submit"
               />
             </client-only>
             <div

--- a/pages/member/account/basic.vue
+++ b/pages/member/account/basic.vue
@@ -36,6 +36,7 @@
                 :value="option.value"
                 class="me-2"
                 :required="field.require"
+                @keyup.enter="submit"
               />
               {{ option.label }}
             </label>
@@ -47,7 +48,8 @@
             :placeholder="`請輸入${field.label}`"
             :has-error="!!errorMessage[field.value]"
             :type="field.type"
-            :disabled="field.label === 'Email'"
+            :disabled="field.disabled"
+            @press-enter="submit"
           />
         </div>
         <div
@@ -98,7 +100,8 @@ interface FieldType {
   value: keyof UserInfoFieldType;
   type: string;
   options?: { label: string; value: string }[];
-  require: boolean;
+  require?: boolean;
+  disabled?: boolean;
 }
 
 const initState: UserInfoFieldType = {
@@ -121,7 +124,8 @@ const fieldList = computed(() => {
     {
       label: 'Email',
       value: 'email',
-      type: 'text'
+      type: 'text',
+      disabled: true
     },
     {
       label: '暱稱',

--- a/pages/member/account/password.vue
+++ b/pages/member/account/password.vue
@@ -22,6 +22,7 @@
           v-model:value="formState[field.value]"
           :placeholder="`請輸入${field.label}`"
           :has-error="!!errorMessage[field.value]"
+          @press-enter="submit"
         />
         <div
           v-if="errorMessage[field.value]"


### PR DESCRIPTION
需求:

1. 填寫表單如登入註冊等時，希望可以直接按下 enter 就送出資料，不用一定要點擊 button

調整:

1. 在 input 上綁定 keyup.enter 事件，按下 enter 時觸發事件