### PR TITLE
feat(issue89): 製作搜尋功能 （尚未接 api）

### DIFF
--- a/assets/scss/config/_variables.scss
+++ b/assets/scss/config/_variables.scss
@@ -881,7 +881,7 @@ $input-focus-border-color: tint-color($component-active-bg, 50%) !default;
 $input-focus-color: $input-color !default;
 $input-focus-width: $input-btn-focus-width !default;
 $input-focus-box-shadow: $input-btn-focus-box-shadow !default;
-$input-placeholder-color: var(--#{$prefix}secondary-color) !default;
+$input-placeholder-color: $gray-400 !default;
 $input-plaintext-color: var(--#{$prefix}body-color) !default;
 $input-height-border: calc(#{$input-border-width} * 2) !default; // stylelint-disable-line function-disallowed-list
 

--- a/components/ArticleLabel.vue
+++ b/components/ArticleLabel.vue
@@ -1,19 +1,37 @@
 <template>
-  <span class="badge bg-transparent fw-bold">{{ text }}</span>
+  <span
+    class="badge bg-transparent fw-bold"
+    :class="isNewsArticle ? 'news-label' : 'magazine-label'"
+  >
+    {{ text }}
+  </span>
 </template>
 <script lang="ts" setup>
 interface ArticleLabelProps {
   text: string;
+  articleId?: ArticleType['articleId'];
 }
 
-withDefaults(defineProps<ArticleLabelProps>(), {
-  text: ''
+const props = withDefaults(defineProps<ArticleLabelProps>(), {
+  text: '',
+  articleId: 'N-'
 });
+
+const isNewsArticle = computed(() => props.articleId?.startsWith('N-'));
 </script>
 <style lang="scss" scoped>
 .badge {
   padding: 5px 10px;
-  border: 1px solid $blue-500;
-  color: $blue-500;
+  border: 1px solid transparent;
+
+  &.news-label {
+    border-color: $primary;
+    color: $primary;
+  }
+
+  &.magazine-label {
+    border-color: $success;
+    color: $success;
+  }
 }
 </style>

--- a/components/GlobalSearch.vue
+++ b/components/GlobalSearch.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="global-search">
+    <teleport
+      to="body"
+      :disabled="!isMobile"
+    >
+      <div
+        class="search-input position-absolute"
+        :class="{ show: showInput }"
+      >
+        <n-input
+          ref="searchInputRef"
+          v-model:value="keyword"
+          inputmode="search"
+          placeholder="搜尋文章標題"
+          suffix-icon="icon/search.svg"
+          :suffix-icon-click-fn="goToSearch"
+          @press-enter="goToSearch"
+          @click-icon="goToSearch"
+        />
+      </div>
+    </teleport>
+    <nav-icon-btn
+      class="position-relative"
+      :class="showInput ? 'opacity-0 z-minus' : 'opacity-100'"
+      icon="search"
+      @click="showInput = true"
+    />
+  </div>
+</template>
+<script lang="ts" setup>
+const isMobile = inject<any>('isMobile');
+const keyword = ref<string>('');
+const route = useRoute();
+
+const showInput = ref<boolean>(false);
+const searchInputRef = ref<HTMLElement | null>(null);
+
+const initInput = () => {
+  showInput.value = false;
+  keyword.value = '';
+};
+
+onClickOutside(searchInputRef, () => {
+  if (isMobile.value || String(route.name) !== 'search') {
+    initInput();
+  }
+});
+
+const goToSearch = async () => {
+  if (keyword.value?.trim() || String(route.name) === 'search') {
+    await navigateTo({
+      path: '/search',
+      query: {
+        keyword: keyword.value || undefined
+      }
+    });
+
+    if (isMobile.value) {
+      initInput();
+    }
+  } else {
+    initInput();
+  }
+};
+
+watch(
+  () => String(route.name),
+  (val) => {
+    if (val !== 'search') {
+      initInput();
+    }
+  }
+);
+</script>
+<style lang="scss" scoped>
+.search-input {
+  width: 0;
+  opacity: 0;
+
+  &.show {
+    opacity: 100;
+  }
+
+  ::v-deep(.n-input input) {
+    height: 40px;
+    transition: padding 0.1s 0.2s ease-in-out;
+  }
+}
+
+@include media-breakpoint-down(md) {
+  .global-search {
+    position: relative;
+  }
+
+  ::v-deep(.suffix-icon) {
+    transform: translateX(2px);
+  }
+
+  .search-input {
+    top: 0;
+    right: 50%;
+    left: 50%;
+    z-index: 12;
+    padding: 8px 12px 0;
+    height: 100%;
+    transition: background 0.3s ease-in-out;
+    transform: translateX(-50%);
+    transform-origin: center;
+
+    &.show {
+      width: 100%;
+      background: rgba($gray-100, 0.7);
+    }
+  }
+}
+
+@include media-breakpoint-up(md) {
+  .global-search {
+    position: relative;
+  }
+
+  ::v-deep(.suffix-icon) {
+    transform: translateX(2px);
+  }
+
+  .search-input {
+    right: 0;
+    transition: all 0.3s ease-in-out;
+
+    &.show {
+      width: 250px;
+    }
+
+    &:not(.show) {
+      ::v-deep(.n-input input) {
+        &.has-suffix-icon {
+          padding-right: 0 !important;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/components/Header/OtherHeader.vue
+++ b/components/Header/OtherHeader.vue
@@ -8,9 +8,7 @@
         <n-logo target-path="/news" />
         <div class="d-flex align-items-center gap-1 gap-md-3">
           <client-only>
-            <nuxt-link to="/search">
-              <nav-icon-btn icon="search" />
-            </nuxt-link>
+            <global-search />
             <notice-bell v-if="token" />
             <avatar-dropdown v-if="token || isMobile" />
             <n-button

--- a/components/NInput.vue
+++ b/components/NInput.vue
@@ -13,9 +13,9 @@
     />
     <div
       v-if="suffixIcon"
-      class="suffix-icon position-absolute h-100 py-2"
+      class="suffix-icon position-absolute h-100 d-flex align-items-center"
       :class="{ 'is-btn': suffixIconClickFn }"
-      @click="suffixIconClickFn"
+      @click="$emit('clickIcon')"
     >
       <img :src="requireImage(suffixIcon)" />
     </div>
@@ -46,7 +46,7 @@ withDefaults(defineProps<NInputProps>(), {
   suffixIconClickFn: undefined
 });
 
-defineEmits<{ (e: 'pressEnter'): void }>();
+defineEmits<{ (e: 'pressEnter'): void; (e: 'clickIcon'): void }>();
 </script>
 <style lang="scss" scoped>
 .n-input {

--- a/components/NPasswordInput.vue
+++ b/components/NPasswordInput.vue
@@ -5,6 +5,7 @@
     :type="inputType"
     :suffix-icon="`icon/eye${eyeType}.svg`"
     :suffix-icon-click-fn="showPasswordHandler"
+    @click-icon="showPasswordHandler"
   />
 </template>
 <script setup lang="ts">

--- a/components/_pages/news/ArticleRow.vue
+++ b/components/_pages/news/ArticleRow.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="news-container">
+    <nuxt-link
+      class="d-flex"
+      :class="
+        size === 'small' ? 'gap-2 news-item pb-2 border-bottom' : 'flex-column gap-4 flex-md-row p-3 border rounded-2'
+      "
+      :to="`/article/${newsData?.topic?.[0]}/${newsData?.articleId}`"
+    >
+      <template v-if="size === 'small'">
+        <div class="news-image-container overflow-hidden rounded-1">
+          <img
+            :src="newsData?.image"
+            class="news-image object-fit-cover"
+          />
+        </div>
+        <div class="d-flex flex-column justify-content-between gap-2 flex-fill">
+          <h6 class="news-title text-body fw-bold limit-line-two">{{ newsData?.title }}</h6>
+          <div class="d-flex align-items-center mt-auto justify-content-between">
+            <article-label
+              :text="newsData?.topic?.[0]"
+              :article-id="newsData?.articleId"
+            />
+            <div class="publish-date text-muted text-end">
+              {{ useDateFormat(newsData?.publishedAt, 'YYYY/MM/DD').value }}
+            </div>
+          </div>
+        </div>
+      </template>
+      <template v-else>
+        <div class="headline-col overflow-hidden rounded-1">
+          <img
+            class="news-image object-fit-cover h-100"
+            :src="newsData?.image"
+          />
+        </div>
+        <div class="headline-col d-flex flex-column gap-3">
+          <h3 class="news-title text-body fw-bold limit-line-two">{{ newsData?.title }}</h3>
+          <img
+            class="wave-icon d-none d-md-inline-block"
+            :src="requireImage('icon/wave-cyan.svg')"
+          />
+          <div class="d-none d-md-block text-muted">
+            <p class="limit-line-four">{{ newsData?.content }}</p>
+          </div>
+          <div class="d-flex align-items-center mt-auto">
+            <article-label
+              :text="newsData?.topic?.[0]"
+              class="me-3"
+              :article-id="newsData?.articleId"
+            />
+            <div class="text-muted flex-fill px-3 border-start border-layout whitespace-nowrap">
+              {{ newsData?.editor }}
+            </div>
+            <div class="publish-date text-muted text-end border-start border-layout">
+              {{ useDateFormat(newsData?.publishedAt, 'YYYY/MM/DD').value }}
+            </div>
+          </div>
+        </div>
+      </template>
+    </nuxt-link>
+  </div>
+</template>
+<script lang="ts" setup>
+interface NewsCardProps {
+  newsData: ArticleType;
+  size?: 'small' | 'big';
+}
+
+withDefaults(defineProps<NewsCardProps>(), {
+  size: 'small'
+});
+</script>
+
+<style lang="scss" scoped>
+.wave-icon {
+  width: 36px;
+}
+
+.news-item {
+  .news-image-container {
+    max-width: 140px;
+  }
+}
+
+.publish-date {
+  width: 108px;
+}
+
+@include media-breakpoint-up(md) {
+  .headline-col {
+    width: 50%;
+  }
+
+  .gx-md-10 {
+    --bs-gutter-x: 40px;
+  }
+
+  .news-container {
+    .news-image,
+    .news-title {
+      transition: all 0.3s ease-in-out;
+    }
+
+    &:hover {
+      .news-image {
+        transform: scale(1.2);
+      }
+
+      .news-title {
+        opacity: 0.5;
+      }
+    }
+  }
+}
+
+@include media-breakpoint-down(md) {
+  .news-page {
+    margin-bottom: 40px;
+  }
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -53,9 +53,21 @@ const route = useRoute();
 
 const { newsNav } = useNav();
 
-const isArticlePage = computed(() => route.name === 'article-category-articleId');
-const showAsideInfo = computed(() => String(route.name)?.startsWith('news') || isArticlePage.value);
-const noTouchEvent = computed(() => !isMobile.value || isArticlePage.value);
+const isArticlePage = computed(() => String(route.name) === 'article-category-articleId');
+
+const showAsideInfo = computed(
+  () => String(route.name) === 'news' || String(route.name) === 'search' || isArticlePage.value
+);
+
+const hasTouchEvent = computed(() => {
+  switch (String(route.name)) {
+    case 'news':
+    case 'magazine':
+      return isMobile.value;
+    default:
+      return false;
+  }
+});
 
 const currentTab = computed(() => {
   switch (route.name) {
@@ -83,19 +95,19 @@ const transformStyle = computed(() => ({
 }));
 
 const pressHandler = () => {
-  if (noTouchEvent.value) return;
+  if (!hasTouchEvent.value) return;
   isPress.value = true;
 };
 
 const releaseHandler = () => {
-  if (noTouchEvent.value) return;
+  if (!hasTouchEvent.value) return;
   setTimeout(() => {
     isPress.value = false;
   }, 100);
 };
 
 const swiperHeader = (direction: string) => {
-  if (noTouchEvent.value) return;
+  if (!hasTouchEvent.value) return;
   if (direction === 'left') {
     navigateTo(swiperRoute.value.next);
   } else {
@@ -108,6 +120,7 @@ const { magazineCategoryList } = storeToRefs(guestStore);
 
 watchImmediate([() => route.fullPath, () => magazineCategoryList.value], () => {
   if (isArticlePage.value) return;
+
   const list = renderBreadcrumb();
   guestStore.SET_BREADCRUMB_NAV(list);
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev --port 4000",
+    "dev": "nuxt dev --port 4000 --host",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/pages/article/[category]/[articleId].vue
+++ b/pages/article/[category]/[articleId].vue
@@ -16,6 +16,7 @@
                   <article-label
                     v-for="item in articleData?.topic"
                     :key="item"
+                    :article-id="articleData?.articleId"
                     :text="item"
                   />
                 </div>

--- a/pages/faq/index.vue
+++ b/pages/faq/index.vue
@@ -26,6 +26,8 @@ useHead({
 </script>
 <style lang="scss" scoped>
 .faq {
+  padding-bottom: 80px;
+
   &-banner {
     margin-bottom: 40px !important;
     padding: 40px 16px;

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -3,67 +3,18 @@
     <n-loading :loading="showLoading">
       <ul
         v-if="renderList.length"
-        class="row gy-4 gx-md-10"
+        class="row gy-4 gx-md-10 align-items-center"
       >
         <li
           v-for="(item, index) in renderList"
           :key="index"
-          class="col-12 news-container"
+          class="col-12"
           :class="{ 'col-md-6': index }"
         >
-          <nuxt-link
-            class="d-flex"
-            :class="index ? 'gap-2 news-item pb-2 border-bottom' : 'flex-column gap-4 flex-md-row p-3 border rounded-2'"
-            :to="`/article/${item?.topic?.[0]}/${item?.articleId}`"
-          >
-            <template v-if="index">
-              <div class="news-image-container overflow-hidden rounded-1">
-                <img
-                  :src="item.image"
-                  class="news-image object-fit-cover"
-                />
-              </div>
-              <div class="d-flex flex-column justify-content-between gap-2 flex-fill">
-                <h6 class="news-title text-body fw-bold limit-line-two">{{ item.title }}</h6>
-                <div class="d-flex align-items-center mt-auto justify-content-between">
-                  <article-label :text="item.topic?.[0]" />
-                  <div class="publish-date text-muted text-end">
-                    {{ useDateFormat(item.publishedAt, 'YYYY/MM/DD').value }}
-                  </div>
-                </div>
-              </div>
-            </template>
-            <template v-else>
-              <div class="headline-col overflow-hidden rounded-1">
-                <img
-                  class="news-image object-fit-cover h-100"
-                  :src="item.image"
-                />
-              </div>
-              <div class="headline-col d-flex flex-column gap-3">
-                <h3 class="news-title text-body fw-bold limit-line-two">{{ item.title }}</h3>
-                <img
-                  class="wave-icon d-none d-md-inline-block"
-                  :src="requireImage('icon/wave-cyan.svg')"
-                />
-                <div class="d-none d-md-block text-muted">
-                  <p class="limit-line-four">{{ item.content }}</p>
-                </div>
-                <div class="d-flex align-items-center mt-auto">
-                  <article-label
-                    :text="item.topic?.[0]"
-                    class="me-3"
-                  />
-                  <div class="text-muted flex-fill px-3 border-start border-layout whitespace-nowrap">
-                    {{ item.editor }}
-                  </div>
-                  <div class="publish-date text-muted text-end border-start border-layout">
-                    {{ useDateFormat(item.publishedAt, 'YYYY/MM/DD').value }}
-                  </div>
-                </div>
-              </div>
-            </template>
-          </nuxt-link>
+          <article-row
+            :news-data="item"
+            :size="index ? 'small' : 'big'"
+          />
         </li>
       </ul>
       <n-empty
@@ -188,44 +139,9 @@ watchDeep(
 );
 </script>
 <style lang="scss" scoped>
-.wave-icon {
-  width: 36px;
-}
-
-.news-item {
-  .news-image-container {
-    max-width: 140px;
-  }
-}
-
-.publish-date {
-  width: 108px;
-}
-
 @include media-breakpoint-up(md) {
-  .headline-col {
-    width: 50%;
-  }
-
   .gx-md-10 {
     --bs-gutter-x: 40px;
-  }
-
-  .news-container {
-    .news-image,
-    .news-title {
-      transition: all 0.3s ease-in-out;
-    }
-
-    &:hover {
-      .news-image {
-        transform: scale(1.2);
-      }
-
-      .news-title {
-        opacity: 0.5;
-      }
-    }
   }
 }
 

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -1,31 +1,141 @@
 <template>
-  <div>
+  <div class="search-page">
     <n-loading :loading="loading">
-      <ul v-if="renderList.length">
-        <li>搜尋頁 7-1</li>
+      <h4
+        v-if="keyword"
+        class="mb-4 text-primary"
+      >
+        {{ `搜尋標題包含「${keyword}」的文章：` }}
+      </h4>
+      <ul
+        v-if="renderList.length && keyword"
+        class="d-flex flex-column gap-4"
+      >
+        <li
+          v-for="(item, index) in renderList"
+          :key="index"
+        >
+          <article-row :news-data="item" />
+        </li>
       </ul>
       <n-empty
-        v-else-if="!loading"
-        text="無搜尋結果"
+        v-else-if="!keyword || !loading"
+        :text="!keyword ? '請輸入搜尋關鍵字' : '無搜尋結果'"
         width="300"
       />
     </n-loading>
+    <n-pagination
+      v-model:current="pagination.current"
+      class="mt-4"
+      :total-pages="pagination.totalPages"
+      :btn-loading="loadMoreLoading"
+    />
   </div>
 </template>
 <script lang="ts" setup>
+import type { PaginationType } from '@/components/NPagination.vue';
+
 useHead({
-  titleTemplate: (title) => `${title} - 搜尋結果`
+  titleTemplate: (title) => `${title} - 搜尋`
+});
+const route = useRoute();
+
+// const isMobile = inject<any>('isMobile');
+
+const pagination = reactive<PaginationType>({
+  current: 1,
+  totalPages: 0
 });
 
-const isMobile = inject<any>('isMobile');
-const noticeList = ref<NoticeType[]>([]);
-const noticePhoneList = ref<NoticeType[]>([]);
+// const searchList = ref<ArticleType[]>([]);
+// const searchPhoneList = ref<ArticleType[]>([]);
+const loadMoreLoading = ref<boolean>(false);
+const loading = ref<boolean>(false);
 
-const loading = ref<boolean>(true);
+const keyword = computed(() => route.query?.keyword);
+// const showLoading = computed(() => {
+//   if (isMobile.value) {
+//     return !pagination.totalPages && loading.value;
+//   }
+//   return loading.value;
+// });
 
-const renderList = computed(() => (isMobile.value ? noticePhoneList.value : noticeList.value));
+// const renderList = computed(() => (isMobile.value ? searchPhoneList.value : searchList.value));
+const renderList = computed(() => [
+  {
+    topic: ['社會'],
+    editor: '聯合新聞網',
+    articleId: 'N-1001',
+    title: '誤把室外熱水器裝在室內 竹北夫妻一氧化碳中毒1死1傷',
+    publishedAt: '2024-01-08 14:22',
+    imageDescribe: '新竹縣竹北市一對夫妻在住家浴室內安裝室外型熱水器,導致一氧化碳中毒,丈夫死亡,妻子受傷住院。',
+    image:
+      'https://pgw.udn.com.tw/gw/photo.php?u=https://uc.udn.com.tw/photo/2024/01/30/realtime/28854189.jpg&s=Y&x=0&y=11&sw=1479&sh=986&exp=3600',
+    content:
+      '新竹縣竹北市今天凌晨0時許發生一氧化碳中毒意外,一對劉姓夫妻疑似天冷洗澡後,熱水器疑似燃燒不完全,釋放出一氧化碳,加上裝置熱水器的陽台加裝鋁門窗阻擋排氣,造成2人一氧化碳中毒,其中42歲丈夫因血液一氧化碳濃度高達63.1%,經搶救無效死亡,32歲妻子血液一氧化碳濃度為26.7%,目前意識清楚、醫院留觀中。\n\n新竹縣消防局指出,今天凌晨0點50分接獲一氧化碳中毒通報,消防人員到場時,一名劉姓男子已呈現昏迷,其妻子意識清楚但肢體無力,消防人員立即將2人送醫搶救,不過由於劉姓男子因嚴重缺氧,經搶救後今天凌晨4時許仍宣告不治。\n\n據了解,這對夫妻和女方媽媽住在同層公寓內,當時因天冷3人晚間輪流洗澡後,熱水器疑似燃燒不完全,釋放出一氧化碳,其中劉妻媽媽發覺頭暈、四肢無力,進房找女兒和女婿求救時,發現2人叫不醒,且呈現無力、昏迷狀態,立即向住在同一棟不同層的兒子(劉妻弟弟)求救,劉妻弟弟到場後撥打119報案。\n\n消防人員到場時發現,屋內遍布一氧化碳氣體,且戶外型熱水器裝在陽台,卻加裝鋁門窗阻擋排氣。雖當時劉妻弟弟表示,陽台窗戶有開一小縫,並未完全關閉,但仍無法完全排出一氧化碳。\n\n新竹縣消防局提醒,冬天因天氣寒冷且風又大,民眾習慣將門窗緊閉,造成空氣不流通,容易產生一氧化碳,導致一氧化碳中毒,請民眾務必注意,燃氣熱水器應安裝於空氣流通處的室外,雖然天氣冷,還是要保持室內通風,且一氧化碳無色無味,但中毒時會有頭暈、噁心、嘔吐、全身無力等症狀,如有以上症狀,立刻關閉熱水器,並打開門窗通風。',
+    tags: ['hot'],
+    source: {
+      name: '聯合新聞網',
+      url: 'https://udn.com/'
+    }
+  },
+  {
+    topic: ['社會'],
+    editor: '聯合新聞網',
+    articleId: 'M-1001',
+    title: '誤把室外熱水器裝在室內 竹北夫妻一氧化碳中毒1死1傷',
+    publishedAt: '2024-01-08 14:22',
+    imageDescribe: '新竹縣竹北市一對夫妻在住家浴室內安裝室外型熱水器,導致一氧化碳中毒,丈夫死亡,妻子受傷住院。',
+    image:
+      'https://pgw.udn.com.tw/gw/photo.php?u=https://uc.udn.com.tw/photo/2024/01/30/realtime/28854189.jpg&s=Y&x=0&y=11&sw=1479&sh=986&exp=3600',
+    content:
+      '新竹縣竹北市今天凌晨0時許發生一氧化碳中毒意外,一對劉姓夫妻疑似天冷洗澡後,熱水器疑似燃燒不完全,釋放出一氧化碳,加上裝置熱水器的陽台加裝鋁門窗阻擋排氣,造成2人一氧化碳中毒,其中42歲丈夫因血液一氧化碳濃度高達63.1%,經搶救無效死亡,32歲妻子血液一氧化碳濃度為26.7%,目前意識清楚、醫院留觀中。\n\n新竹縣消防局指出,今天凌晨0點50分接獲一氧化碳中毒通報,消防人員到場時,一名劉姓男子已呈現昏迷,其妻子意識清楚但肢體無力,消防人員立即將2人送醫搶救,不過由於劉姓男子因嚴重缺氧,經搶救後今天凌晨4時許仍宣告不治。\n\n據了解,這對夫妻和女方媽媽住在同層公寓內,當時因天冷3人晚間輪流洗澡後,熱水器疑似燃燒不完全,釋放出一氧化碳,其中劉妻媽媽發覺頭暈、四肢無力,進房找女兒和女婿求救時,發現2人叫不醒,且呈現無力、昏迷狀態,立即向住在同一棟不同層的兒子(劉妻弟弟)求救,劉妻弟弟到場後撥打119報案。\n\n消防人員到場時發現,屋內遍布一氧化碳氣體,且戶外型熱水器裝在陽台,卻加裝鋁門窗阻擋排氣。雖當時劉妻弟弟表示,陽台窗戶有開一小縫,並未完全關閉,但仍無法完全排出一氧化碳。\n\n新竹縣消防局提醒,冬天因天氣寒冷且風又大,民眾習慣將門窗緊閉,造成空氣不流通,容易產生一氧化碳,導致一氧化碳中毒,請民眾務必注意,燃氣熱水器應安裝於空氣流通處的室外,雖然天氣冷,還是要保持室內通風,且一氧化碳無色無味,但中毒時會有頭暈、噁心、嘔吐、全身無力等症狀,如有以上症狀,立刻關閉熱水器,並打開門窗通風。',
+    tags: ['hot'],
+    source: {
+      name: '聯合新聞網',
+      url: 'https://udn.com/'
+    }
+  }
+]);
 
-onMounted(() => {
-  loading.value = false;
-});
+const getSearchPageHandler = async () => {
+  loading.value = true;
+  loadMoreLoading.value = pagination.totalPages > 1;
+
+  // const params = {
+  //   pageIndex: pagination.current,
+  //   keyword: keyword.value || undefined
+  // };
+  // const { status, data } = await getSearchPage(params);
+  // if (status) {
+  //   searchList.value = data.comments || [];
+
+  //   searchPhoneList.value = pagination.current === 1 ? data.comments : [...searchPhoneList.value, ...data.comments];
+
+  // pagination.totalPages = data.totalPages || 0;
+  pagination.totalPages = 1;
+  // } else {
+  //   searchList.value = [];
+  // }
+
+  setTimeout(() => {
+    loading.value = false;
+    loadMoreLoading.value = false;
+  }, 1000);
+};
+
+watchImmediate(
+  () => keyword.value,
+  (val) => {
+    if (val) {
+      pagination.current = 1;
+      getSearchPageHandler();
+    }
+  }
+);
 </script>
+<style lang="scss" scoped>
+.search-page {
+  margin-bottom: 40px;
+}
+</style>

--- a/utils/renderBreadcrumb.ts
+++ b/utils/renderBreadcrumb.ts
@@ -19,6 +19,12 @@ export default (): NavItemType[] => {
       label: magazineItem?.categoryName || '',
       value: `/magazine/${magazineItem?.categoryId}`
     });
+  } else if (route.name === 'search') {
+    list = newsNav.filter((e) => e.label === '首頁');
+    list.push({
+      label: '搜尋',
+      value: ''
+    });
   } else {
     list = [];
   }


### PR DESCRIPTION
需求:

1. 製作搜尋功能

調整:

1. 依照設計稿調整 header 搜尋 btn  交互

(1) 手機版用全域遮罩

(2) 電腦版為 input 欄位伸縮

2. 搜尋的文章卡片同新聞頁的小新聞卡片

3. articleLabel.vue 加上 props 判斷，新聞為藍色、雜誌為綠色