### PR TITLE
fix(issue103): header 搜尋加上 loading

### DIFF
--- a/components/GlobalSearch.vue
+++ b/components/GlobalSearch.vue
@@ -6,11 +6,12 @@
     >
       <div
         class="search-input position-absolute"
-        :class="{ show: showInput }"
+        :class="{ show: showInput, 'opacity-50': disabledInput }"
       >
         <n-input
           ref="searchInputRef"
           v-model:value="keyword"
+          :disabled="disabledInput"
           inputmode="search"
           placeholder="搜尋文章標題"
           suffix-icon="icon/search.svg"
@@ -32,6 +33,7 @@
 const isMobile = inject<any>('isMobile');
 const keyword = ref<string>('');
 
+const disabledInput = ref<boolean>(false);
 const showInput = ref<boolean>(false);
 const searchInputRef = ref<HTMLElement | null>(null);
 
@@ -42,6 +44,8 @@ const initInput = () => {
 
 const goToSearch = async () => {
   if (keyword.value?.trim()) {
+    disabledInput.value = true;
+
     await navigateTo({
       path: '/search',
       query: {
@@ -50,6 +54,8 @@ const goToSearch = async () => {
         topic: 'all'
       }
     });
+
+    disabledInput.value = false;
   } else {
     initInput();
   }

--- a/components/NInput.vue
+++ b/components/NInput.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="n-input d-flex align-items-center position-relative">
+  <div
+    class="n-input d-flex align-items-center position-relative"
+    :class="{ 'cursor-not-allowed': disabled }"
+  >
     <input
       :id="id"
       v-model="value"
@@ -7,15 +10,15 @@
       :type="type"
       :inputmode="inputmode"
       class="form-control fs-sm py-2"
-      :class="{ 'invalid-field': hasError, 'has-suffix-icon': suffixIcon }"
+      :class="{ 'invalid-field': hasError, 'has-suffix-icon': suffixIcon, 'cursor-not-allowed': disabled }"
       :disabled="disabled"
       @keyup.enter="$emit('pressEnter')"
     />
     <div
       v-if="suffixIcon"
       class="suffix-icon position-absolute h-100 d-flex align-items-center"
-      :class="{ 'is-btn': suffixIconClickFn }"
-      @click="$emit('clickIcon')"
+      :class="{ 'is-btn': suffixIconClickFn && !disabled }"
+      @click="disabled ? '' : $emit('clickIcon')"
     >
       <img :src="requireImage(suffixIcon)" />
     </div>
@@ -57,7 +60,6 @@ defineEmits<{ (e: 'pressEnter'): void; (e: 'clickIcon'): void }>();
   input:disabled {
     background-color: #f5f5f5;
     color: #999;
-    cursor: not-allowed;
   }
 }
 


### PR DESCRIPTION
調整:

1. header 的搜尋框的點擊行為是跳轉不是 call api，所以不加上 loading，只加上 disabled 狀態，參考 google 搜尋