### PR TITLE
fix(categoryImage): 雜誌文章列表圖片高度不一

### DIFF
--- a/pages/magazine/[category].vue
+++ b/pages/magazine/[category].vue
@@ -46,7 +46,7 @@
             <div class="overflow-hidden">
               <n-image
                 :img-src="magazineContent?.categoryImg || ''"
-                class="card-img-top"
+                class="card-img-top object-fit-cover"
                 :alt="item.imageDescribe || ''"
               />
             </div>
@@ -177,8 +177,7 @@ watch(
 }
 
 .card .card-img-top {
-  height: 250px;
-  object-fit: cover;
+  height: 250px !important;
   transition: all 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
問題:

1. 原本圖片高度有設定 250px 但權重被覆蓋

原因:

1. nImage 內有 class h-100，權重為 important

調整:

1. 外層 class 加上 important