### PR TITLE
fix(issue98): 編輯個人資料可以暫存到localstorage避免切換就call api

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -41,6 +41,10 @@ onMounted(async () => {
 
     if (token.value) {
       userStore.getUserData();
+
+      if (route.name === 'member-account-basic') {
+        userStore.getUserInfo();
+      }
     } else {
       userStore.$reset();
     }

--- a/pages/login-register/index.vue
+++ b/pages/login-register/index.vue
@@ -222,15 +222,15 @@ const submit = async () => {
     userStore.SET_USER_INFO(data);
     token.value = data?.token;
 
-    showToast({
-      id: 'login-success',
-      message
-    });
-
     setTimeout(async () => {
       await userStore.getUserData();
       await goBack();
       btnLoading.value = false;
+
+      showToast({
+        id: 'login-success',
+        message
+      });
     }, 100);
   } else {
     showToast({

--- a/pages/member/index.vue
+++ b/pages/member/index.vue
@@ -50,7 +50,7 @@
           <div class="d-flex justify-content-center">
             <nuxt-link
               :to="`/subscription-plan`"
-              class="text-decoration-underline text-accent"
+              class="text-decoration-underline text-accent is-btn"
               >了解訂閱方案</nuxt-link
             >
           </div>
@@ -139,8 +139,6 @@ const nTabsBus = useEventBus('nTabsBus');
 definePageMeta({
   title: '會員中心'
 });
-
-await useAsyncData('user-data', () => userStore.getUserData());
 
 interface FieldType {
   label: string;


### PR DESCRIPTION
問題:

1. 目前每進一次修改個人資料頁就會 call 一次 userInfo api，可以第一次沒資料時 call，後續都取 localstorage 資料

調整:

1. 判斷沒有 gender 時才 call （因為 gender 在剛開始登入時不會取得）

2. 重整後還是建議要重 call 一次 userInfo 故在 app.vue 內加上判斷

3. 調整 formState 取得 user store 的方式 (watchEffect)

4. 調整 account-basic 內驗證判斷