### PR TITLE
fix(animate): 調整動畫相關問題

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -3,7 +3,7 @@
     <n-page-loading />
     <teleport to="body">
       <n-toast />
-      <notice-modal />
+      <notice-modal v-if="token" />
     </teleport>
     <n-header v-if="!isLoginPage" />
     <nuxt-layout class="layouts">

--- a/assets/scss/config/_utilities.scss
+++ b/assets/scss/config/_utilities.scss
@@ -58,7 +58,8 @@ $utilities: map-merge(
       class: 'whitespace',
       responsive: true,
       values: (
-        'nowrap': nowrap
+        'nowrap': nowrap,
+        'pre-wrap': pre-wrap
       )
     )
   )

--- a/components/NAccordion.vue
+++ b/components/NAccordion.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    id="accordionFlushExample"
+    id="nAccordion"
     class="accordion accordion-flush"
   >
     <div
@@ -8,7 +8,10 @@
       :key="item.title"
       class="accordion-item bg-transparent"
     >
-      <h3 class="accordion-header py-4">
+      <h3
+        :id="`heading-${index}`"
+        class="accordion-header py-4"
+      >
         <button
           class="accordion-button collapsed"
           type="button"
@@ -23,14 +26,15 @@
       <div
         :id="`flush-collapse${index}`"
         class="accordion-collapse collapse"
-        data-bs-parent="#accordionFlushExample"
+        :aria-labelledby="`heading-${index}`"
+        data-bs-parent="#nAccordion"
       >
         <div class="accordion-body">
           <img
             class="wave-icon mb-3"
             :src="requireImage('icon/wave-cyan.svg')"
           />
-          <p class="mb-0 fs-md-5 text-pre-wrap">{{ item.content }}</p>
+          <p class="mb-0 fs-md-5 whitespace-pre-wrap">{{ item.content }}</p>
         </div>
       </div>
     </div>
@@ -77,7 +81,9 @@ withDefaults(defineProps<NAccordionProps>(), {
   width: 36px;
 }
 
-.text-pre-wrap {
-  white-space: pre-wrap;
+@include media-breakpoint-down(md) {
+  .collapsing {
+    transition: height 0.15s linear !important;
+  }
 }
 </style>

--- a/components/NTransition.vue
+++ b/components/NTransition.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    ref="target"
+    ref="targetRef"
     class="n-transition"
     :style="{ '--delay': `${delay}s` }"
-    :class="[animationName, targetIsVisible ? 'show opacity-100' : 'opacity-0']"
+    :class="[animationName, showTarget ? 'show opacity-100' : 'opacity-0']"
   >
     <slot />
   </div>
@@ -14,12 +14,9 @@ interface NTransitionProps {
   delay?: number;
 }
 
-const target = ref(null);
-const targetIsVisible = ref(false);
-
-const { stop } = useIntersectionObserver(target, ([{ isIntersecting }]) => {
-  targetIsVisible.value = isIntersecting;
-});
+const scrollY = inject<any>('scrollY');
+const targetRef = ref<HTMLElement | null>(null);
+const showTarget = ref<boolean>(false);
 
 withDefaults(defineProps<NTransitionProps>(), {
   animationName: 'fade-in-up',
@@ -27,10 +24,12 @@ withDefaults(defineProps<NTransitionProps>(), {
 });
 
 watch(
-  () => targetIsVisible.value,
+  () => scrollY.value,
   (val) => {
-    if (val) {
-      stop();
+    if (val < 30) {
+      showTarget.value = false;
+    } else if ((targetRef.value?.getBoundingClientRect()?.y || 0) < (window.innerHeight * 5) / 7) {
+      showTarget.value = true;
     }
   }
 );

--- a/components/_pages/subscription-plan/MagazineSupplier.vue
+++ b/components/_pages/subscription-plan/MagazineSupplier.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="magazine-supplier">
+  <n-transition class="magazine-supplier">
     <swiper
       v-for="(swiper, index) in swiperList"
       :key="index"
@@ -31,7 +31,7 @@
         </client-only>
       </swiper-slide>
     </swiper>
-  </div>
+  </n-transition>
 </template>
 <script lang="ts" setup>
 const topSupplierList = [

--- a/pages/article/[category]/[articleId].vue
+++ b/pages/article/[category]/[articleId].vue
@@ -42,7 +42,7 @@
                 </figcaption>
               </figure>
 
-              <p class="card-text mx-2 pb-3 mx-md-4 pb-md-4 border-bottom mb-2">
+              <p class="whitespace-pre-wrap mx-2 pb-3 mx-md-4 pb-md-4 border-bottom mb-2">
                 {{ articleData?.content }}
               </p>
               <footer class="p-3">
@@ -183,10 +183,6 @@ useHead({
 <style lang="scss" scoped>
 .card.has-paywall {
   padding-bottom: 150px;
-}
-
-.card-text {
-  white-space: pre-wrap;
 }
 
 @include media-breakpoint-up(md) {


### PR DESCRIPTION
問題:

1. nAccordion 在手機看動畫會卡卡的

2. nTransition 在頁面剛載入就已經進入可視區的元素可能會沒有偵測到導致不顯示

調整:

1. nAccordion 的問題尚未找出原因

(1) 僅有測試出移除 container-fluid 後動畫就很順，只要有更動 accordion-item 的 border 或 radius 等項目就會卡

(2) 目前僅先調整手機版的動畫速度快一些

2. nTransition 改為用 window 高度與 DOM 座標比對顯示