### PR TITLE
fix(issue111): 方案卡片跳轉到雜誌頁畫面錯誤

### DIFF
--- a/components/_pages/subscription-plan/PlanSelection.vue
+++ b/components/_pages/subscription-plan/PlanSelection.vue
@@ -169,12 +169,16 @@ const goToPage = (item: PlanItem) => {
       break;
     default:
       if (token.value) {
-        navigateTo({
-          path: item.redirectPath,
-          query: {
-            plan: isVip.value ? undefined : item.type
-          }
-        });
+        if (isVip.value) {
+          window.location.href = item.redirectPath || '';
+        } else {
+          navigateTo({
+            path: item.redirectPath,
+            query: {
+              plan: item.type
+            }
+          });
+        }
       } else {
         showHintModal.value = true;
       }


### PR DESCRIPTION
問題:

1. 訂閱會員點方案卡片前往使用要跳到雜誌頁，網址正確，畫面卻還是上一頁的畫面

調整:

1. 目前看只有這邊跳轉到 /magazine 會有問題，不知道原因為何，先用原生跳轉方式