### PR TITLE
fix(image): 修正新聞、雜誌文章圖片問題

### DIFF
--- a/components/_pages/news/ArticleRow.vue
+++ b/components/_pages/news/ArticleRow.vue
@@ -3,12 +3,14 @@
     <nuxt-link
       class="d-flex"
       :class="
-        size === 'small' ? 'gap-2 news-item pb-2 border-bottom' : 'flex-column gap-4 flex-md-row p-3 border rounded-2'
+        size === 'small'
+          ? 'small-news-card gap-2 pb-2 border-bottom'
+          : 'big-news-card flex-column gap-3 flex-md-row p-3 border rounded-2'
       "
       :to="`/article/${isMagazine ? newsData?.source?.name : newsData?.topic?.[0]}/${newsData?.articleId}`"
     >
       <template v-if="size === 'small'">
-        <div class="news-image-container overflow-hidden rounded-1 flex-shrink-0">
+        <div class="overflow-hidden rounded-1 flex-shrink-0">
           <article-image
             :article-data="newsData"
             class="news-image object-fit-cover"
@@ -34,10 +36,10 @@
         </div>
       </template>
       <template v-else>
-        <div class="headline-col overflow-hidden rounded-1">
+        <div class="headline-col overflow-hidden rounded-1 flex-shrink-0">
           <article-image
             :article-data="newsData"
-            class="news-image object-fit-cover h-100"
+            class="news-image big object-fit-cover h-100"
           />
         </div>
         <div class="headline-col d-flex flex-column gap-3">
@@ -80,9 +82,16 @@ const isMagazine = computed(() => props.newsData?.articleId?.startsWith('M-'));
 </script>
 
 <style lang="scss" scoped>
-.news-item {
-  .news-image-container {
-    max-width: 140px;
+.big-news-card {
+  .news-image {
+    height: 250px !important;
+  }
+}
+
+.small-news-card {
+  .news-image {
+    width: 133px;
+    height: 88px !important;
   }
 }
 
@@ -91,6 +100,12 @@ const isMagazine = computed(() => props.newsData?.articleId?.startsWith('M-'));
 }
 
 @include media-breakpoint-up(md) {
+  .big-news-card {
+    .news-image {
+      height: 306px !important;
+    }
+  }
+
   .headline-col {
     width: 50%;
   }

--- a/pages/article/[category]/[articleId].vue
+++ b/pages/article/[category]/[articleId].vue
@@ -31,13 +31,13 @@
               </header>
               <figure
                 v-if="articleData?.image || articleData?.articleId?.startsWith('M-')"
-                class="mb-md-4"
+                class="mx-2 mb-md-4 border-bottom mx-md-4"
               >
                 <article-image
                   :article-data="articleData"
                   class="news-image rounded-1 mb-2 d-block mx-auto"
                 />
-                <figcaption class="fs-sm text-muted mx-2 pt-2 pb-3 border-bottom pt-md-3 pb-md-4 mx-md-4">
+                <figcaption class="image-desc mx-auto fs-sm text-muted pt-2 pb-3 pt-md-3 pb-md-4">
                   {{ articleData?.imageDescribe }}
                 </figcaption>
               </figure>
@@ -186,8 +186,9 @@ useHead({
 }
 
 @include media-breakpoint-up(md) {
-  .news-image {
-    max-width: 75%;
+  .news-image,
+  .image-desc {
+    max-width: 80%;
   }
 }
 </style>

--- a/pages/magazine/[category].vue
+++ b/pages/magazine/[category].vue
@@ -42,10 +42,9 @@
         <nuxt-link :to="`/article/${$route.params.category}/${item.articleId}`">
           <div class="card overflow-hidden">
             <div class="overflow-hidden">
-              <n-image
-                :img-src="magazineContent?.categoryImg || ''"
+              <article-image
+                :article-data="item"
                 class="card-img-top object-fit-cover"
-                :alt="item.imageDescribe || ''"
               />
             </div>
             <n-tag


### PR DESCRIPTION
問題:

1. 新聞列表頁的圖片沒有限制到高度導致比較高的圖片會讓版面跑版

2. 雜誌文章列表頁的圖片沒有取文章本身的圖

調整:

1. 依照設計稿寫死圖片寬高

2. 雜誌文章列表頁的圖片改用 articleImage 共用判斷