### PR TITLE
feat(loginRegister): 調整登入註冊頁

### DIFF
--- a/components/NPageLoading.vue
+++ b/components/NPageLoading.vue
@@ -1,55 +1,38 @@
 <template>
   <div
-    class="loading-indicator position-fixed top-0 start-0 w-100 h-100 d-flex justify-content-center align-items-center"
-    :class="{ show: isLoading }"
+    class="loading-indicator bg-body position-fixed top-0 start-0 w-100 h-100 d-flex justify-content-center align-items-center"
+    :class="{ hidden: !isLoading }"
   >
     <div class="loader" />
   </div>
 </template>
 
 <script setup lang="ts">
-// const nuxtApp = useNuxtApp();
+const nuxtApp = useNuxtApp();
 const pageLoadingBus = useEventBus('pageLoadingBus');
-const isLoading = ref(false);
-
-// const unsubPageStart = nuxtApp.hook('page:start', () => {
-//   if (process.client) {
-//     console.log('start');
-//     isLoading.value = true;
-//   }
-// });
+const isLoading = ref(true);
 
 const loadingHandler: any = (bool: boolean): void => {
   isLoading.value = bool;
 };
 
-// const unsubPageFinish = nuxtApp.hook('page:finish', () => {
-//   if (process.client) {
-//     console.log('finish');
-//     setTimeout(() => {
-//       isLoading.value = false;
-//       console.log('isLoading.value :>> ', isLoading.value);
-//     }, 400);
-//   }
-// });
+nuxtApp.hook('page:loading:end', () => {
+  if (process.client) {
+    isLoading.value = false;
+  }
+});
 
 onBeforeMount(() => {
   pageLoadingBus.on(loadingHandler);
 });
-
-// onBeforeUnmount(() => {
-//   unsubPageStart();
-//   unsubPageFinish();
-// });
 </script>
 <style lang="scss" scoped>
 .loading-indicator {
-  z-index: -1;
-  background: rgba($gray-100, 0.7);
+  z-index: $zindex-fixed;
   transition: opacity 0.5s ease-in-out;
 
-  &.show {
-    z-index: $zindex-fixed;
+  &.hidden {
+    z-index: -1;
   }
 }
 

--- a/pages/login-register/index.vue
+++ b/pages/login-register/index.vue
@@ -7,7 +7,7 @@
       ref="formBoxContainerRef"
       class="form-box-container rounded-3 flex-lg-fill px-lg-4 position-relative z-1"
     >
-      <div class="field-container">
+      <div class="field-container d-flex flex-column">
         <header>
           <n-logo
             class="mx-auto"
@@ -16,7 +16,7 @@
           <h3 class="text-center my-4">{{ modeText.name }}</h3>
         </header>
         <form
-          class="row gy-4 needs-validation fs-sm"
+          class="row needs-validation fs-sm mb-3"
           :class="{ 'was-invalidated': isInvalidated }"
           novalidate
         >
@@ -52,22 +52,43 @@
               />
             </client-only>
             <div
-              v-if="errorMessage[field.value]"
-              class="invalid-feedback"
+              class="invalid-feedback d-block mb-1"
+              :class="{ invisible: !isInvalidated }"
             >
-              {{ errorMessage[field.value] }}
+              {{ errorMessage[field.value] || '-' }}
             </div>
           </div>
           <div class="col-12">
+            <p
+              v-if="mode === 'register'"
+              class="fs-sm mb-2 text-muted"
+            >
+              註冊即代表同意我們的
+              <nuxt-link
+                class="is-btn"
+                to="/policy/terms-of-service"
+                target="_blank"
+              >
+                服務條款
+              </nuxt-link>
+              與
+              <nuxt-link
+                class="is-btn"
+                to="/policy/privacy-policy"
+                target="_blank"
+              >
+                隱私權政策
+              </nuxt-link>
+            </p>
             <n-button
-              class="w-100 mb-3"
+              class="w-100"
               :text="modeText.name"
               :loading="btnLoading"
               @click="submit"
             />
           </div>
         </form>
-        <p class="fs-sm text-center mb-0">
+        <p class="fs-sm text-center mb-0 mt-auto">
           {{ modeText.hint }}
           <a
             class="text-primary is-btn"
@@ -261,6 +282,14 @@ const imageList = [
   {
     img: 'https://cdn.pixabay.com/photo/2017/06/18/18/26/holi-2416686_1280.jpg',
     desc: 'Capturing the World’s Stories, One Frame at a Time - Syed Murtaza Ali'
+  },
+  {
+    img: 'https://cdn.pixabay.com/photo/2016/11/23/15/32/pedestrians-1853552_1280.jpg',
+    desc: '在都市中，人們在繁華的街道上匆匆忙忙地來往 - 聯合新聞網'
+  },
+  {
+    img: 'https://images.volleyballworld.com/image/upload/t_editorial_landscape_12_desktop/f_auto/v1719519033/fivb-prd/wjkdxcjroqj0zeyib7qd.jpg',
+    desc: 'Yuki Ishikawa led Japan to a sweep of Canada in the quarterfinals - Volleyball Nations league'
   }
 ];
 
@@ -268,7 +297,7 @@ const bgImageObj = ref<any>({});
 
 watch([() => loginRegisterRef.value, () => formBoxContainerRef.value], (val) => {
   if (val[0] && val[1]) {
-    bgImageObj.value = imageList[Math.round(Math.random())] || imageList[0];
+    bgImageObj.value = imageList[Math.round(Math.random() * imageList.length)] || imageList[0];
     const bgImage = `url(${bgImageObj.value.img})`;
     val.forEach((e: HTMLElement | null) => {
       e?.style.setProperty('--bg-image', bgImage);
@@ -280,10 +309,6 @@ watch([() => loginRegisterRef.value, () => formBoxContainerRef.value], (val) => 
 .login-register {
   overflow-y: auto;
   min-height: 100vh;
-}
-
-.invalid-feedback {
-  margin-bottom: -15px;
 }
 
 .form-box-container {
@@ -357,7 +382,7 @@ watch([() => loginRegisterRef.value, () => formBoxContainerRef.value], (val) => 
   }
 
   .field-container {
-    height: 524px;
+    height: 552px;
   }
 
   .form-box-container {

--- a/pages/policy/privacy-policy/index.vue
+++ b/pages/policy/privacy-policy/index.vue
@@ -47,7 +47,7 @@
           如果您對我們的隱私權政策、我們如何使用您的個人資訊、行使您的隱私權有任何疑問，或是對於 NewsWave
           服務、您的帳號有一般問題，請隨時
           <nuxt-link
-            class="is-btn"
+            class="is-btn text-blue-400"
             to="/contact-us"
             target="_blank"
           >

--- a/pages/policy/terms-of-service/index.vue
+++ b/pages/policy/terms-of-service/index.vue
@@ -30,6 +30,7 @@
             <div class="fw-bold">隱私權：</div>
             我們尊重您的隱私權，不會將您的個人資訊用於其他目的。請仔細閱讀我們的
             <nuxt-link
+              class="is-btn text-blue-400"
               to="/policy/privacy-policy"
               target="_blank"
             >
@@ -51,7 +52,7 @@
         <div>
           「NewsWave Plus」為 NewsWave 提供的訂閱服務，若對於 NewsWave Plus 服務有一般疑問亦可參考我們的
           <nuxt-link
-            class="is-btn"
+            class="is-btn text-blue-400"
             target="_blank"
             to="/faq"
           >
@@ -86,7 +87,7 @@
         <p class="mb-0">
           如果您對我們的服務條款有任何疑問，請隨時
           <nuxt-link
-            class="is-btn"
+            class="is-btn text-blue-400"
             to="/contact-us"
             target="_blank"
           >


### PR DESCRIPTION
調整:

1. 註冊表單補上服務條款、隱私權政策敘述

2. 調整排版

(1) 錯誤訊息出現時不會讓版面長高

(2) 前往登入/註冊 的提示改為置底

3. 新增兩張背景圖

4. 加上全域 page loading 圖，在第一次開啟網頁時出現

5. 調整政策頁的連結顏色，加強與黑色字的對比