### PR TITLE
fix(magazine): 修正雜誌相關地方

### DIFF
--- a/components/_pages/Home/SelectedMagazine.vue
+++ b/components/_pages/Home/SelectedMagazine.vue
@@ -4,7 +4,7 @@
       <n-transition>
         <h2 class="text-body-white">精選雜誌</h2>
         <n-swiper
-          :swiper-list="magazineCategoryList"
+          :swiper-list="magazineCategoryList.slice(0, 6)"
           mode="dark"
         >
           <template #slide="{ slideItem }">

--- a/components/_pages/news/ArticleRow.vue
+++ b/components/_pages/news/ArticleRow.vue
@@ -24,12 +24,12 @@
           >
             {{ newsData?.content }}
           </p>
-          <div class="d-flex align-items-center mt-auto justify-content-between">
+          <div class="d-flex align-items-center mt-auto justify-content-between gap-1 flex-wrap">
             <article-label
               :text="newsData?.topic?.[0]"
               :article-id="newsData?.articleId"
             />
-            <div class="publish-date text-muted text-end">
+            <div class="text-muted text-end">
               {{ useDateFormat(newsData?.publishedAt, 'YYYY/MM/DD').value }}
             </div>
           </div>

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -177,4 +177,18 @@ watchDeep(
     transform: translate(50px, 0);
   }
 }
+
+@include media-breakpoint-up(xl) {
+  ::v-deep(.news-container) {
+    .small-news-card {
+      .news-title {
+        height: 54px;
+      }
+
+      .news-image {
+        height: 95px !important;
+      }
+    }
+  }
+}
 </style>


### PR DESCRIPTION
問題:

1. 雜誌文章調整 topic 欄位名稱太常會導致搜尋頁卡片爆版

2. 首頁的精選雜誌區塊目前會顯示所有雜誌種類，但預期顯示前六種即可

調整:

1. articleRow 的 small news card 的 tag、日期區塊改成可以換行

2. 精選雜誌用 slice 只取前六種

3. 調整新聞頁 small news card 的高度要一致